### PR TITLE
If path does not exist or there is a typo in it return error msg for user

### DIFF
--- a/countfiles.py
+++ b/countfiles.py
@@ -79,6 +79,10 @@ def main_flow(args: Type[argparse_namespace_object]):
         location = os.path.expanduser(args.path)
         loc_text = ':\n' + location
 
+    if os.path.exists(location) is False:
+        print(f'The path {location} does not exist or there is a typo in it.')
+        return
+
     # Either search and list files by extension...
     if search_by_extension:
         len_files = fc.get_files_by_extension(location, args.file_extension,


### PR DESCRIPTION
Hello!
I tried to count the files in one folder and the parser did not return the results. The thing was that there was a typo in the name of the folder. It was necessary to enter a name: "/some-folder",  instead I print the "/some_folder".
I get "Oops! We have no data to show ... ". It's true, but such a folder does not even exist :)
I suggest adding a  os.path.exists(path)  for location.