### PR TITLE
groups in the ArgumentParser, changes in the display of --help

### DIFF
--- a/countfiles/settings.py
+++ b/countfiles/settings.py
@@ -13,3 +13,6 @@ not_supported_type_message = f'Sorry, there is no preview available for this fil
                              f'\nThis is the list of currently supported file types: ' \
                              f'{", ".join(sorted(list(chain.from_iterable(SUPPORTED_TYPES.values()))))}. ' \
                              f'\nYou may want to try again without preview.\n\n'
+
+supported_type_info_message = f'This is the list of currently supported file types for preview: ' \
+                              f'{", ".join(sorted(list(chain.from_iterable(SUPPORTED_TYPES.values()))))}. '


### PR DESCRIPTION
changelog:
changes in the display of --help
- groups and their description in the ArgumentParser (main.py)
- added -st, --supported-types argument (main.py), action - display the list of currently supported file types for preview
- added supported_type_info_message for -st argument (settings.py)
- updated mention of the license - MIT (main.py)

Help appearance:
```
>python countfiles -h
usage: countfiles [-h] [-v] [-st] [-a] [-nr] [-alpha] [-nt]
                  [-fe FILE_EXTENSION] [-p] [-ps PREVIEW_SIZE] [-nl]
                  [path]

Count files, grouped by extension, in a directory. By default, it will count
files recursively in current working directory and all of its subdirectories,
and will display a table showing the frequency for each file extension (e.g.:
.txt, .py, .html, .css) and the total number of files found. Any hidden files
or folders (those with names starting with '.') are ignored by default.

positional arguments:
  path                  The path to the folder containing the files to be
                        counted.

optional arguments:
  -h, --help            show this help message and exit
  -v, --version         show program's version number and exit
  -st, --supported-types
                        The list of currently supported file types for
                        preview.
  -a, --all             Include hidden files and directories (names starting
                        with '.')
  -nr, --no-recursion   Don't recurse through subdirectories

File counting by extension:
  Counting all files in the specified directory with or without extensions.
  Default settings: recursively count all files, ignoring hidden files and
  directories; path - the current working directory; view mode - a table
  with file extensions sorted by frequency. Usage: countfiles [-a] [-nr]
  [-alpha] [-nt] [path]

  -alpha, --sort-alpha  Sort the table alphabetically, by file extension.
  -nt, --no-table       Don't show the table, only the total number of files

File searching by extension:
  Search for files with a given extension. Default settings: recursively
  search all files, ignoring hidden files and directories; path - the
  current working directory; view mode - a list with full file paths. Usage:
  countfiles [-a] [-nr] [-fe FILE_EXTENSION] [-p] [-ps PREVIEW_SIZE] [-nl]
  [path]

  -fe FILE_EXTENSION, --file-extension FILE_EXTENSION
                        Search files by file extension (use a single dot '.'
                        to search for files without any extension)
  -p, --preview         Display a short preview (only available for text files
                        when using '-fe' or '--file_extension')
  -ps PREVIEW_SIZE, --preview-size PREVIEW_SIZE
                        Specify the number of characters to be displayed from
                        each found file when using '-p' or '--preview')
  -nl, --no-list        Don't show the list, only the total number of files
                        and information about file sizes
```
