### PR TITLE
updated functions with new args.no_feedback, cprofile and timeit tests, def count_files_by_extension vs def search_files

### DIFF
--- a/countfiles/__main__.py
+++ b/countfiles/__main__.py
@@ -23,14 +23,16 @@ from countfiles.settings import not_supported_type_message, supported_type_info_
 
 
 parser = ArgumentParser(
+    prog='countfiles',
     description="Count files, grouped by extension, in a directory. By "
                 "default, it will count files recursively in current "
                 "working directory and all of its subdirectories, and "
                 "will display a table showing the frequency for each file "
                 "extension (e.g.: .txt, .py, .html, .css) and the total "
                 "number of files found. Any hidden files or folders "
-                "(those with names starting with '.') are ignored by "
-                "default.")
+                "are ignored by default."
+                "(Windows: files and directories for which FILE_ATTRIBUTE_HIDDEN is true; "
+                "Linux, Mac OS: those with names starting with '.')")
 
 parser.add_argument('-v', '--version', action='version', version='<the version>')
 
@@ -43,10 +45,10 @@ parser.add_argument('path', nargs="?", default=os.getcwd(), type=str,
 parser.add_argument('-a', '--all', action='store_true',
                     help="Include hidden files and directories. "
                          "Windows: files and directories for which FILE_ATTRIBUTE_HIDDEN is true; "
-                         "Linux, Mac OS: names starting with '.' ")
+                         "Linux, Mac OS: those with names starting with '.'(dot)")
 
 parser.add_argument('-nr', "--no-recursion", action='store_true',
-                    help="Don't recurse through subdirectories")
+                    help="Don't recurse through subdirectories.")
 
 parser.add_argument('-nf', "--no-feedback", action='store_true', default=False,
                     help="Don't show the program's operating indicator"
@@ -71,7 +73,7 @@ count_group.add_argument('-alpha', '--sort-alpha', action='store_true',
                          help="Sort the table alphabetically, by file extension.")
 
 count_group.add_argument('-nt', '--no-table', action='store_true',
-                         help="Don't show the table, only the total number of files")
+                         help="Don't show the table, only the total number of files.")
 
 search_group = parser.add_argument_group("File searching by extension",
                                          description="Search for files with a given extension. "
@@ -88,18 +90,19 @@ search_group = parser.add_argument_group("File searching by extension",
 
 search_group.add_argument('-fe', '--file-extension', type=str,
                           help="Search files by file extension (use a single dot '.' to search for "
-                          "files without any extension)")
+                          "files without any extension).")
 
 search_group.add_argument('-p', '--preview', action='store_true',
                           help="Display a short preview (only available for text files when "
-                          "using '-fe' or '--file_extension')")
+                          "using '-fe' or '--file_extension').")
 
 search_group.add_argument('-ps', '--preview-size', type=int, default=DEFAULT_PREVIEW_SIZE,
                           help="Specify the number of characters to be displayed from each "
-                          "found file when using '-p' or '--preview')")
+                          "found file when using '-p' or '--preview'.")
 
 search_group.add_argument('-nl', '--no-list', action='store_true',
-                          help="Don't show the list, only the total number of files and information about file sizes")
+                          help="Don't show the list, "
+                               "only the total number of files and information about file sizes.")
 
 
 argparse_namespace_object = TypeVar('argparse_namespace_object', bound=Namespace)

--- a/countfiles/utils/word_counter.py
+++ b/countfiles/utils/word_counter.py
@@ -5,7 +5,7 @@ from typing import Iterable
 
 from countfiles.utils.file_handlers import human_mem_size
 from countfiles.utils.file_preview import generate_preview
-from countfiles.settings import DEFAULT_PREVIEW_SIZE
+from countfiles.settings import DEFAULT_PREVIEW_SIZE, TERM_WIDTH
 
 
 def show_2columns(data):
@@ -46,7 +46,7 @@ def show_total(data) -> int:
     return total
 
 
-def show_result_for_search_files(files: Iterable[str], no_list: bool, preview: bool = False,
+def show_result_for_search_files(files: Iterable[str], no_list: bool, no_feedback: bool, preview: bool = False,
                                  preview_size: int = DEFAULT_PREVIEW_SIZE) -> int:
     """Print list of all found file paths, preview and size info
     or only the total number and size info(summary).
@@ -54,6 +54,7 @@ def show_result_for_search_files(files: Iterable[str], no_list: bool, preview: b
     :param files: list with paths
     :param no_list: view mode, False -> for now list(show list with paths, preview and size info),
     True -> no-list(show only the total number and size info)
+    :param no_feedback: True or False(default, prints processed file names in one line)
     :param preview: optional, args.preview, True or False
     :param preview_size: optional, args.preview_size, number
     :return: len(files), print view mode
@@ -95,6 +96,9 @@ def show_result_for_search_files(files: Iterable[str], no_list: bool, preview: b
                 files_amount += 1
                 file_size = os.path.getsize(f_path)
                 sizes.append(file_size)
+                if not no_feedback:
+                    print("\r" + os.path.basename(f_path)[:TERM_WIDTH - 1].ljust(TERM_WIDTH - 1), end="")
+            print("\r".ljust(TERM_WIDTH - 1))  # Clean the feedback text before proceeding.
         except StopIteration:
             print(f"No files were found in the specified directory.\n")
             return 0

--- a/tests/compare_tables/show_result_no_list.txt
+++ b/tests/compare_tables/show_result_no_list.txt
@@ -1,3 +1,4 @@
+                                                                              
 
    Found 2 file(s).
    Total combined size: 49.0 B.

--- a/tests/compare_tables/test_show_result_no_list.txt
+++ b/tests/compare_tables/test_show_result_no_list.txt
@@ -1,3 +1,4 @@
+                                                                              
 
    Found 2 file(s).
    Total combined size: 49.0 B.

--- a/tests/performance_tests/cprofile_test.py
+++ b/tests/performance_tests/cprofile_test.py
@@ -1,0 +1,43 @@
+"""https://docs.python.org/3.6/library/profile.html
+
+profile.run(command, filename=None, sort=-1)
+This function takes a single argument that can be passed to the exec() function,
+and an optional file name.
+The column headings include:
+ncalls for the number of calls.
+tottime for the total time spent in the given function (and excluding time made in calls to sub-functions)
+percall is the quotient of tottime divided by ncalls
+cumtime is the cumulative time spent in this and all subfunctions (from invocation till exit).
+This figure is accurate even for recursive functions.
+percall is the quotient of cumtime divided by primitive calls
+filename:lineno(function) provides the respective data of each function
+"""
+import cProfile
+import os
+import sys
+from countfiles.utils.file_handlers import search_files, count_file_extensions1, count_files_by_extension
+from countfiles.__main__ import main_flow
+
+
+def get_locations(*args):
+    return os.path.normpath(os.path.join(os.path.expanduser('~/'), *args))
+
+
+if __name__ == "__main__":
+
+    if sys.platform.startswith('win'):
+        location = get_locations('Desktop')
+    elif sys.platform.startswith('darwin'):
+        # specify folder
+        pass
+    elif sys.platform.startswith('linux'):
+        # specify folder
+        pass
+
+    # cProfile.run("main_flow([location, '-a'])", sort='name')
+    # cProfile.run("main_flow([location, '-a', '-fe', 'txt'])", sort='name')
+    cProfile.run("data = count_files_by_extension(dirpath=location, no_feedback=False,"
+                 "recursive=True, include_hidden=True)", sort='name')
+    cProfile.run("data = search_files(dirpath=location, extension='', recursive=True, include_hidden=True); "
+                 "counter = count_file_extensions1(file_paths=data, no_feedback=False)", sort='name')
+

--- a/tests/performance_tests/timeit_test.py
+++ b/tests/performance_tests/timeit_test.py
@@ -1,0 +1,49 @@
+"""https://docs.python.org/3.6/library/timeit.html
+
+Timer(stmt='pass', setup='pass', timer=<timer function>, globals=None)
+Timer.repeat(repeat=3, number=1000000)
+"""
+import timeit
+import sys
+import os
+from countfiles.utils.file_handlers import search_files, count_file_extensions1, count_files_by_extension
+from countfiles.__main__ import main_flow
+
+
+def get_locations(*args):
+    return os.path.normpath(os.path.join(os.path.expanduser('~/'), *args))
+
+
+main_no_feedback_no_table = """
+main_flow([location, '-a', '-nf', '-nt'])
+"""
+
+main_feedback_table = """
+main_flow([location, '-a'])
+"""
+
+search_files_feedback = """
+data = search_files(dirpath=location, extension='', recursive=True, include_hidden=True)
+counter = count_file_extensions1(file_paths=data, no_feedback=False)
+"""
+
+count_files_feedback = """
+data = count_files_by_extension(dirpath=location, no_feedback=False, recursive=True, include_hidden=True)
+"""
+
+
+if __name__ == "__main__":
+
+    if sys.platform.startswith('win'):
+        location = get_locations('Desktop')
+    elif sys.platform.startswith('darwin'):
+        # specify folder
+        pass
+    elif sys.platform.startswith('linux'):
+        # specify folder
+        pass
+
+    stmts = [search_files_feedback, count_files_feedback]
+    for s in stmts:
+        t = timeit.Timer(stmt=s, globals=globals())
+        print(s, t.repeat(repeat=3, number=1))

--- a/tests/test_some_functions.py
+++ b/tests/test_some_functions.py
@@ -65,7 +65,8 @@ class TestSomeFunctions(unittest.TestCase):
         Expected behavior: return object <class 'collections.Counter'>
         :return:
         """
-        result = count_files_by_extension(self.get_locations('data_for_tests'), recursive=False, include_hidden=False)
+        result = count_files_by_extension(self.get_locations('data_for_tests'), no_feedback=True,
+                                          recursive=False, include_hidden=False)
         self.assertEqual(str(result), "Counter({'html': 1, 'md': 1, '[no extension]': 1, 'py': 1})")
 
     @unittest.skipUnless(sys.platform.startswith('win'), 'for Windows')

--- a/tests/test_word_counter.py
+++ b/tests/test_word_counter.py
@@ -52,7 +52,7 @@ class TestWordCounter(unittest.TestCase):
         test1 = self.get_locations('compare_tables', 'test_show_result_no_list.txt')
         with open(test1, 'w') as f:
             with redirect_stdout(f):
-                show_result_for_search_files(files=data, no_list=True)
+                show_result_for_search_files(files=data, no_list=True, no_feedback=True)
         self.assertEqual(filecmp.cmp(test1, self.get_locations('compare_tables', 'show_result_no_list.txt'),
                                      shallow=False), True)
 

--- a/tests/test_word_counter.py
+++ b/tests/test_word_counter.py
@@ -16,7 +16,7 @@ class TestWordCounter(unittest.TestCase):
     def test_show_2columns(self):
         test1 = self.get_locations('compare_tables', 'test_2columns_sorted.txt')
         test2 = self.get_locations('compare_tables', 'test_2columns_most_common.txt')
-        data = count_files_by_extension(dirpath=self.get_locations('data_for_tests'),
+        data = count_files_by_extension(dirpath=self.get_locations('data_for_tests'), no_feedback=True,
                                         include_hidden=False, recursive=True)
         with open(test1, 'w') as f:
             with redirect_stdout(f):


### PR DESCRIPTION
changelog:
- added cprofile_test.py and timeit_test.py into tests/
- added the feedback for ```--no-list``` in utils/word_counter.py(def show_result_for_search_files)
- added new args.no_feedback in main.py, utils/file_handlers.py(def count_files_by_extension),
utils/word_counter.py(def show_result_for_search_files)
  - added the ability to disable feedback
- now feedback is available by default for table, no-table, no-list(for the list, feedback already exists in the form of the list itself)
- updated functions with new args.no_feedback(tests/, def test_count_files_by_extension, def test_show_result_for_search_files and def test_show_2columns)
- def count_files_by_extension vs def search_files(added def count_file_extensions1), switch to def search_files in counting files part for further check
- updated ArgumentParser help text(hidden files and directories, groups description)
- updated comments(note for behavior of def is_hidden_file_or_dir if the path does not exist)
