### PR TITLE
del --no-table and --no-list from ArgumentParser (replace with --total)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,9 @@
 logs/
 
 # ignore tests/compare_tables
-tests/compare_tables/show_result_no_list.txt
-tests/compare_tables/test_show_result_no_list.txt
+tests/compare_tables/test_show_result_list.txt
+tests/compare_tables/darwin_show_result_list.txt
+tests/compare_tables/win_show_result_list.txt
 
 ### PyCharm ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm

--- a/tests/compare_tables/win_show_result_no_list.txt
+++ b/tests/compare_tables/win_show_result_no_list.txt
@@ -1,6 +1,0 @@
-                                                                              
-
-   Found 2 file(s).
-   Total combined size: 49.0 B.
-   Average file size: 24.0 B (max: 49.0 B, min: 0.0 B).
-

--- a/tests/performance_tests/cprofile_test.py
+++ b/tests/performance_tests/cprofile_test.py
@@ -53,7 +53,6 @@ if __name__ == "__main__":
 
     # total number of files
     cProfile.run("main_flow([location, '-t', '..', '-a'])", sort='name')
-    cProfile.run("main_flow([location, '-nt', '-a'])", sort='name')
 
     # lists
     # cProfile.run("main_flow([location, '-fe', '.', '-fs', '-a'])", sort='name')

--- a/tests/performance_tests/timeit_test.py
+++ b/tests/performance_tests/timeit_test.py
@@ -15,10 +15,6 @@ def get_locations(*args):
     return os.path.normpath(os.path.join(os.path.expanduser('~/'), *args))
 
 
-main_nt = """
-main_flow([location, '-a', '-nt'])
-"""
-
 main_fe = """
 main_flow([location, '-a', '-fe', 'txt'])
 """
@@ -62,7 +58,5 @@ if __name__ == "__main__":
     print(total, t.repeat(repeat=3, number=1))
     # t = timeit.Timer(total_by_extension, globals=globals())
     # print(total_by_extension, t.repeat(repeat=3, number=1))
-    # t = timeit.Timer(main_nt, globals=globals())
-    # print(main_nt, t.repeat(repeat=3, number=1))
     # t = timeit.Timer(main_fe, globals=globals())
     # print(main_fe, t.repeat(repeat=3, number=1))

--- a/tests/test_argument_parser.py
+++ b/tests/test_argument_parser.py
@@ -13,16 +13,16 @@ class TestArgumentParser(unittest.TestCase):
         return os.path.normpath(os.path.join(os.path.dirname(__file__), *args))
 
     # thread - ...or do other stuff, i.e., counting files.
-    def test_countfiles_all_nt(self):
+    def test_countfiles_all_t(self):
         """Testing def main_flow.
 
         Recursive/non recursive counting.
         Testing for hidden files is not carried out here.
-        Equivalent to "python __main__.py ~/.../tests/data_for_tests -a -nt"
+        Equivalent to "python __main__.py ~/.../tests/data_for_tests -a -t .."
         :return:
         """
-        self.assertEqual(main_flow([self.get_locations('data_for_tests'), '-nt']), 16)
-        self.assertEqual(main_flow([self.get_locations('data_for_tests'), '-nt', '-nr']), 6)
+        self.assertEqual(main_flow([self.get_locations('data_for_tests'), '-t', '..']), 16)
+        self.assertEqual(main_flow([self.get_locations('data_for_tests'), '-t', '..', '-nr']), 6)
 
     # thread - if search_by_extension:
     def test_countfiles_fe(self):
@@ -53,24 +53,24 @@ class TestArgumentParser(unittest.TestCase):
         """Testing def main_flow.
 
         Equivalent to
-        "python __main__.py ~/.../tests/data_for_tests -nr"
-        and "python __main__.py ~/.../tests/data_for_tests -nr -a"
+        "python __main__.py ~/.../tests/data_for_tests -nr -t .."
+        and "python __main__.py ~/.../tests/data_for_tests -nr -a -t .."
         :return:
         """
-        self.assertEqual(main_flow([self.get_locations('test_hidden_linux'), '-nr', '-nt']), 1)
-        self.assertEqual(main_flow([self.get_locations('test_hidden_linux'), '-nr', '-nt', '-a']), 2)
+        self.assertEqual(main_flow([self.get_locations('test_hidden_linux'), '-nr', '-t', '..']), 1)
+        self.assertEqual(main_flow([self.get_locations('test_hidden_linux'), '-nr', '-t', '..', '-a']), 2)
 
     @unittest.skipUnless(sys.platform.startswith('win'), 'for Windows')
     def test_for_hidden_win(self):
         """Testing def main_flow.
 
         Equivalent to
-        "python __main__.py ~/.../tests/data_for_tests -nr"
-        and "python __main__.py ~/.../tests/data_for_tests -nr -a"
+        "python __main__.py ~/.../tests/data_for_tests -nr -t .."
+        and "python __main__.py ~/.../tests/data_for_tests -nr -a -t .."
         :return:
         """
-        self.assertEqual(main_flow([self.get_locations('test_hidden_windows'), '-nr', '-nt']), 1)
-        self.assertEqual(main_flow([self.get_locations('test_hidden_windows'), '-nr', '-nt', '-a']), 2)
+        self.assertEqual(main_flow([self.get_locations('test_hidden_windows'), '-nr', '-t', '..']), 1)
+        self.assertEqual(main_flow([self.get_locations('test_hidden_windows'), '-nr', '-t', '..', '-a']), 2)
 
 # from root directory:
 

--- a/tests/test_word_counter.py
+++ b/tests/test_word_counter.py
@@ -31,17 +31,13 @@ class TestWordCounter(unittest.TestCase):
                                      shallow=False), True)
 
     # TODO:  test show_result_for_search_files() for different OS
-    # TODO: It is necessary to update.
+    # compare lists with paths and file sizes, for different OS and PC lists will be different
     def test_show_result_for_search_files(self):
         """Testing def show_result_for_search_files. Search by extension.
         Comparison of the file with the results of the function with the specified file.
 
-        Expected behavior:
-        no_list=True
-        Found ... file(s).
-        Total combined size: ... KiB.
-        Average file size: ... KiB (max: ... KiB, min: ... B).
-        no_list=False default
+        Expected behavior: List with paths and file sizes.
+
         full/path/to/file1.extension (... KiB)
         full/path/to/file2.extension (... KiB)
         ...
@@ -51,17 +47,17 @@ class TestWordCounter(unittest.TestCase):
         :return:
         """
         if sys.platform.startswith('win'):
-            standard = 'win_show_result_no_list.txt'
+            standard = 'win_show_result_list.txt'
         elif sys.platform.startswith('darwin'):
-            standard = 'darwin_show_result_no_list.txt'
+            standard = 'darwin_show_result_list.txt'
         elif sys.platform.startswith('linux'):
-            standard = 'linux_show_result_no_list.txt'
+            standard = 'linux_show_result_list.txt'
         data = search_files(dirpath=self.get_locations('data_for_tests'), extension='.',
                             include_hidden=False, recursive=True, case_sensitive=False)
-        test1 = self.get_locations('compare_tables', 'test_show_result_no_list.txt')
+        test1 = self.get_locations('compare_tables', 'test_show_result_list.txt')
         with open(test1, 'w') as f:
             with redirect_stdout(f):
-                show_result_for_search_files(files=data, no_list=True, no_feedback=True)
+                show_result_for_search_files(files=data, file_sizes=True)
         self.assertEqual(filecmp.cmp(test1, self.get_locations('compare_tables', standard),
                                      shallow=False), True)
 


### PR DESCRIPTION
changelog:
- remove `--no-table` and `--no-list` from ArgumentParser
- added to gitignore: for different OS and PC lists will be different
tests/compare_tables/test_show_result_list.txt
tests/compare_tables/darwin_show_result_list.txt
tests/compare_tables/win_show_result_list.txt
- updated some tests
For darwin, you need to create new test files to compare the lists.
Just run the test, the file `test_show_result_list.txt` will be created. It can be copied and named `darwin_show_result_list.txt`
- updated help text, `--total` is a separate group.