### PR TITLE
updated exeptions decorator, initial tests for skipping hidden root folders (Windows)

### DIFF
--- a/count_files/__main__.py
+++ b/count_files/__main__.py
@@ -34,7 +34,7 @@ from count_files.utils.viewing_modes import show_result_for_search_files
 from count_files.settings import not_supported_type_message, supported_type_info_message, \
     DEFAULT_PREVIEW_SIZE, START_TEXT_WIDTH
 
-# from count_files.utils.decorators import exceptions_decorator
+from count_files.utils.decorators import exceptions_decorator
 
 
 parser = ArgumentParser(
@@ -132,7 +132,7 @@ parser._optionals.title = parser._optionals.title.upper()
 argparse_namespace_object = TypeVar('argparse_namespace_object', bound=Namespace)
 
 
-# @exceptions_decorator
+@exceptions_decorator
 def main_flow(*args: [argparse_namespace_object, Union[bytes, str]]):
     """Main application function.
 
@@ -183,7 +183,6 @@ def main_flow(*args: [argparse_namespace_object, Union[bytes, str]]):
                    width=START_TEXT_WIDTH),
               end="\n\n"
               )
-
         if args.extension == '..':
             result = get_total(dirpath=location,
                                include_hidden=include_hidden,

--- a/count_files/utils/decorators.py
+++ b/count_files/utils/decorators.py
@@ -9,7 +9,6 @@ def exceptions_decorator(func):
     """Registration and interception of the main exceptions.
 
     :param func: executable function
-    :param logger: the logging object
     :return:
     """
     @wraps(func)

--- a/tests/performance_tests/cprofile_test.py
+++ b/tests/performance_tests/cprofile_test.py
@@ -29,7 +29,7 @@ def get_locations(*args):
 if __name__ == "__main__":
 
     if sys.platform.startswith('win'):
-        location = get_locations('Desktop')
+        location = get_locations('Count-files')
     elif sys.platform.startswith('darwin'):
         # specify folder
         pass
@@ -54,8 +54,11 @@ if __name__ == "__main__":
                  sort='name')"""
 
     # total number of files
-    cProfile.run("main_flow([location, '-t', '..', '-a'])", sort='name')
+    # cProfile.run("main_flow([location, '-t', '..', '-a'])", sort='name')
 
     # lists
     # cProfile.run("main_flow([location, '-fe', '.', '-fs', '-a'])", sort='name')
     # cProfile.run("main_flow([location, '-fe', '.', '-a'])", sort='name')
+
+    # win optimization, skipping hidden root folders
+    cProfile.run("main_flow([location, '-fe', '.'])", sort='name')

--- a/tests/performance_tests/timeit_test.py
+++ b/tests/performance_tests/timeit_test.py
@@ -45,10 +45,15 @@ recursive=True)
 print('Result:', len(list(r)))
 """
 
+win_optim_test = """
+main_flow([location, '-fe', '.'])
+"""
+
+
 if __name__ == "__main__":
 
     if sys.platform.startswith('win'):
-        location = get_locations()
+        location = get_locations('Count-files')
     elif sys.platform.startswith('darwin'):
         # specify folder
         pass
@@ -56,8 +61,9 @@ if __name__ == "__main__":
         # specify folder
         pass
 
-    t = timeit.Timer(total, globals=globals())
-    print(total, t.repeat(repeat=3, number=1))
+    # win optimization, skipping hidden root folders
+    t = timeit.Timer(win_optim_test, globals=globals())
+    print(win_optim_test, t.repeat(repeat=3, number=1))
     # t = timeit.Timer(total_by_extension, globals=globals())
     # print(total_by_extension, t.repeat(repeat=3, number=1))
     # t = timeit.Timer(main_fe, globals=globals())


### PR DESCRIPTION
Hello!
- updated exeptions decorator
- initial tests for skipping hidden root folders (Windows)
I have not made any significant functional changes yet.
We can say that skipping hidden folders speeds up file processing in Windows.
I want to test it on Linux, and also whether this optimization will be effective for folders that have no hidden subfolders.