### PR TITLE
added help system extension(search in the help text), ordering old tests

### DIFF
--- a/count_files/__main__.py
+++ b/count_files/__main__.py
@@ -33,7 +33,7 @@ from count_files.utils.viewing_modes import show_2columns, show_start_message
 from count_files.utils.viewing_modes import show_result_for_search_files
 from count_files.settings import not_supported_type_message, supported_type_info_message, \
     DEFAULT_PREVIEW_SIZE, START_TEXT_WIDTH
-
+from count_files.utils.help_system_extension import search_in_help
 from count_files.utils.decorators import exceptions_decorator
 
 
@@ -74,6 +74,13 @@ parser.add_argument('-nf', '--no-feedback', action='store_true', default=False,
                          'Feedback is available by default for counting files by extension '
                          '(table) and for counting the total number of files ("-t" or "--total"). '
                          'This option disables it.')
+
+parser.add_argument('-ah', '--args-help', type=str, dest='argument',
+                    help='Search in help by keyword - argument or group name(count, search, total). '
+                         'Show more detailed help text: count-files -ah docs. '
+                         'Show list of argument or group names: count-files -ah list. '
+                         'Usage: count-files -ah <keyword>.')
+
 
 total_group = parser.add_argument_group('Total number of files'.upper(),
                                         description='Displaying the number of files that either have a '
@@ -154,6 +161,10 @@ def main_flow(*args: [argparse_namespace_object, Union[bytes, str]]):
 
     if args.supported_types:
         parser.exit(status=0, message=supported_type_info_message)
+
+    if args.argument:
+        search_in_help(args.argument)
+        parser.exit(status=0)
 
     if os.path.abspath(args.path) == os.getcwd():
         location = os.getcwd()

--- a/count_files/settings.py
+++ b/count_files/settings.py
@@ -3,6 +3,8 @@
 import shutil
 import platform
 
+
+DOCUMENTATION_URL = 'https://github.com/victordomingos/Count-files#documentation'
 BUG_REPORT_URL = 'https://github.com/victordomingos/Count-files/issues'
 
 TERM_WIDTH = shutil.get_terminal_size((80, 24)).columns

--- a/count_files/utils/help_system_extension.py
+++ b/count_files/utils/help_system_extension.py
@@ -1,0 +1,71 @@
+"""HELP SYSTEM EXTENSION
+
+"""
+from textwrap import fill
+from itertools import chain
+from typing import List
+
+from count_files.utils.help_text import help_system_message_general, \
+   help_system_message_list, arguments, group_names, search_words, indexes
+from count_files.utils import help_text
+from count_files.settings import START_TEXT_WIDTH
+
+
+def print_help_message(title: str, help_system_message: str or List[dict]):
+    """Print an adaptive and formatted help message.
+
+    :param title: headline
+    :param help_system_message: string or List[dict] with args example and description
+    :return:
+    """
+    if isinstance(help_system_message, str):
+        print(fill(title, width=START_TEXT_WIDTH, initial_indent=' ' * 2, subsequent_indent=' ' * 2))
+        print(fill(help_system_message, width=START_TEXT_WIDTH, initial_indent=' ' * 6, subsequent_indent=' ' * 6))
+        return
+    else:
+        print(fill(title, width=START_TEXT_WIDTH, initial_indent=' ' * 2, subsequent_indent=' ' * 2))
+        for item in help_system_message:
+            print(fill(item['desc'], width=START_TEXT_WIDTH, initial_indent=' ' * 2, subsequent_indent=' ' * 2))
+            print(fill(item['args'], width=START_TEXT_WIDTH, initial_indent=' ' * 6, subsequent_indent=' ' * 6))
+        return
+
+
+def search_in_help(keyword: str):
+    """Search for help text by keyword(argument or group name, search words).
+
+    Display corresponding help message for:
+    count-files --args-help docs
+        print help_text.__doc__
+        this HELP SYSTEM EXTENSION DOCS from count_files.utils.help_text.py
+    count-files --args-help list
+        print arguments, group_names, search_words from count_files.utils.help_text.py
+    count-files --args-help <keyword>
+        searching or sorting using indexes from count_files.utils.help_text.py
+        default: show long description for <keyword in lower case>,
+        show short description for <keyword with all or one letter in upper case>
+    :param keyword: argument or group name, search words in lower or upper case
+    :return:
+    """
+    key_lower = keyword.lower()
+    if key_lower == 'docs':
+        for item in help_text.__doc__.split('\n'):
+            print(fill(item,  width=START_TEXT_WIDTH, initial_indent=' ' * 2, subsequent_indent=' ' * 2))
+    elif key_lower == 'list':
+        print('  KEYWORDS:')
+        print_help_message('Available arguments:', ', '.join(arguments))
+        print_help_message('Available group names:', ', '.join(group_names))
+        print_help_message('Available search words:', ', '.join(search_words))
+        print_help_message('ALSO USE:', help_system_message_list)
+    elif key_lower not in set(chain.from_iterable(indexes.keys())):
+        print(fill(f'Not found: {keyword}', width=START_TEXT_WIDTH, initial_indent=' ' * 2, subsequent_indent=' ' * 2))
+        print_help_message('ALSO USE:', help_system_message_general)
+    else:
+        for k, v in indexes.items():
+            if key_lower in k:
+                print(fill(str(v[0]), width=START_TEXT_WIDTH, initial_indent=' ' * 2, subsequent_indent=' ' * 2))
+                # show long description
+                if keyword == key_lower:
+                    print(fill(f'Long: {v[2]}', width=START_TEXT_WIDTH, initial_indent=' ' * 6, subsequent_indent=' ' * 6))
+                # show short description
+                else:
+                    print(fill(f'Short: {v[1]}', width=START_TEXT_WIDTH, initial_indent=' ' * 6, subsequent_indent=' ' * 6))

--- a/count_files/utils/help_text.py
+++ b/count_files/utils/help_text.py
@@ -14,7 +14,7 @@ Web Docs in English, Portuguese, Russian and Ukrainian:
 KEYWORD USAGE:
 
 Keyword - argument or group name, certain search words for sorting.
-    count-files --ah <keyword>
+    count-files -ah <keyword>
     count-files --args-help <keyword>
 Show short help text: Keyword must be in upper case or with one letter in upper case.
     count-files --args-help <keyword in upper case>

--- a/count_files/utils/help_text.py
+++ b/count_files/utils/help_text.py
@@ -350,17 +350,17 @@ indexes = {
     ('nf', 'no-feedback', 'no', 'feedback', 'common', 'optional'):
         [args['no-feedback']['name'], args['no-feedback']['short'], args['no-feedback']['long']],
 
-    ('total-group', 'groups', 'total', 'group', 'tg'):
+    ('total-group', 'groups', 'total', 'tg'):
         [args['total-group']['name'], args['total-group']['short'], args['total-group']['long']],
     ('t', 'total', 'extension', 'special', 'optional'):
         [args['total']['name'], args['total']['short'], args['total']['long']],
 
-    ('count-group', 'groups', 'count', 'group', 'cg'):
+    ('count-group', 'groups', 'count', 'cg'):
         [args['count-group']['name'], args['count-group']['short'], args['count-group']['long']],
     ('alpha', 'sort-alpha', 'count', 'special', 'optional'):
         [args['sort-alpha']['name'], args['sort-alpha']['short'], args['sort-alpha']['long']],
 
-    ('search-group', 'groups', 'search', 'group', 'sg'):
+    ('search-group', 'groups', 'search', 'sg'):
         [args['search-group']['name'], args['search-group']['short'], args['search-group']['long']],
     ('fe', 'file-extension', 'file', 'extension', 'search', 'special', 'optional'):
         [args['file-extension']['name'], args['file-extension']['short'], args['file-extension']['long']],

--- a/count_files/utils/help_text.py
+++ b/count_files/utils/help_text.py
@@ -1,0 +1,377 @@
+"""HELP SYSTEM EXTENSION DOCS.
+
+ALSO USE:
+
+Get the standard argparse help with a brief description of all the arguments.
+    count-files --help
+Get this help system extension usage examples.
+    count-files --args-help docs
+Get a list of available keywords for search.
+    count-files --args-help list
+Web Docs in English, Portuguese, Russian and Ukrainian:
+    https://github.com/victordomingos/Count-files#documentation
+
+KEYWORD USAGE:
+
+Keyword - argument or group name, certain search words for sorting.
+    count-files --ah <keyword>
+    count-files --args-help <keyword>
+Show short help text: Keyword must be in upper case or with one letter in upper case.
+    count-files --args-help <keyword in upper case>
+Show more detailed help text: Keyword must be in lower case.
+    count-files --args-help <keyword in lower case>
+
+Search by short/long argument name:
+Short argument name.
+    count-files --args-help st
+Long argument name.
+    count-files --args-help supported-types
+Partial argument name if it consists of two words.
+    count-files --args-help supported
+    count-files --args-help types
+
+Sorting arguments by purpose:
+Service arguments: display of help, version of the program etc.
+(h or help, ah or args-help, v or version, st or supported-types)
+All service arguments.
+    count-files --args-help service
+Get by name.
+    count-files --args-help help
+
+Common arguments: directory path and sorting settings that are common to search and count.
+(path, a or all, c or case-sensitive, nr or no-recursion, nf or no-feedback)
+All common arguments.
+    count-files --args-help common
+Get by name.
+    count-files --args-help no-recursion
+
+Special arguments: arguments for counting or searching files.
+Count by extension: alpha or sort-alpha;
+Total number of files: t or total;
+Search by extension: fe or file-extension, fs or file-sizes, p or preview, ps or preview-size.
+All special arguments.
+    count-files --args-help special
+Get by name.
+    count-files --args-help file-extension
+
+Sorting arguments by type:
+    count-files --args-help positional
+    count-files --args-help optional
+
+Sorting arguments by group, including group description:
+    count-files --args-help count
+    count-files --args-help search
+    count-files --args-help total
+
+Get group description:
+(count-group or cg, search-group or sg, total-group or tg)
+    count-files --args-help count-group
+    count-files --args-help tg
+
+Get all group descriptions:
+    count-files --args-help groups
+"""
+from count_files.settings import DOCUMENTATION_URL
+
+
+docs = {
+    'args': 'count-files --args-help docs',
+    'desc': 'Get help system extension usage examples.'
+}
+keywords_list = {
+    'args': 'count-files --args-help list',
+    'desc': 'Get a list of available keywords for search.'
+}
+standard = {
+    'args': 'count-files --help',
+    'desc': 'Get the standard argparse help with a brief description of all the arguments.'
+}
+web = {
+    'args': DOCUMENTATION_URL,
+    'desc': 'Web Docs in English, Portuguese, Russian and Ukrainian:'
+}
+
+help_system_message_general = [standard, docs, keywords_list,  web]
+help_system_message_list = [standard, docs, web]
+
+arguments = [
+    # common arguments(positional)
+    'path',
+    # service arguments(optional)
+    'h', 'help', 'ah', 'args-help', 'v', 'version', 'st', 'supported-types',
+    # common arguments(optional)
+    'a', 'all', 'c', 'case-sensitive',
+    'nr', 'no-recursion', 'nf', 'no-feedback',
+    # special arguments(optional)
+    'alpha', 'sort-alpha',
+    'fe', 'file-extension', 'fs', 'file-sizes',
+    'p', 'preview', 'ps', 'preview-size',
+    't', 'total',
+]
+
+group_names = [
+    # certain group description
+    'cg', 'count-group', 'sg', 'search-group', 'tg', 'total-group',
+    # all group descriptions
+    'groups'
+]
+search_words = [
+    # sorting by purpose
+    'service', 'common', 'special',
+    # sorting by argument type
+    'positional', 'optional',
+    # sorting by group, including group description
+    'count', 'search', 'total',
+]
+
+# all argument and group names descriptions(short and long help text)
+args = {
+    'help': {
+        'name': '-h, --help',
+        'short': 'Built-in argparse help system with a brief description of all the arguments. '
+                 'Show help message and exit.',
+        'long': 'Built-in argparse help system with a brief description of all the arguments. '
+                'Show help message and exit. '
+                'Usage: count-files -h or count-files --help.'
+    },
+    'args-help': {
+        'name': '-ah ARGUMENT, --args-help ARGUMENT',
+        'short': 'Search in help by keyword - argument or group name(count, search, total). '
+                 'Show more detailed help text: count-files -ah docs. '
+                 'Show list of argument or group names: count-files -ah list. '
+                 'Usage: count-files -ah <keyword>.',
+        'long': 'Show more detailed help text: count-files -ah docs.'
+    },
+    'version': {
+        'name': '-v, --version',
+        'short': "Show program's version number and exit.",
+        'long': "Show program's version number and exit. "
+                'Usage: count-files -v or count-files --version.'
+    },
+    'supported-types': {
+        'name': '-st, --supported-types',
+        'short': 'The list of currently supported file types for preview.',
+        'long': 'Show a list of currently supported file types for preview and exit. '
+                'Usage: count-files -st or count-files --supported-types.'
+    },
+    'path': {
+        'name': 'path',
+        'short': 'The path to the folder containing the files to be counted.',
+        'long': 'The path to the folder containing the files to be counted. '
+                'If you leave this argument empty, it will scan the current working directory. '
+                "To process files in the user's home directory, you can use ~ (tilde). "
+                'For example: count-files ~/Documents <arguments>. '
+                'Common argument for counting and searching by extension '
+                'or counting the total number of files.'
+    },
+    'all': {
+        'name': '-a, --all',
+        'short': 'Include hidden files and directories.',
+        'long': 'Include hidden files and directories. '
+                'By default, it will ignore files and directories that are supposed to be hidden. '
+                'In Windows, files and directories considered hidden by this application '
+                'are those for which the FILE_ATTRIBUTE_HIDDEN attribute is set to true. '
+                'In Linux, macOS, iOS and other Unix-like operating systems, '
+                'a file or directory is considered to be hidden if its name starts with a "." (dot). '
+                'Common argument for counting and searching by extension '
+                'or counting the total number of files.'
+    },
+    'no-recursion': {
+        'name': '-nr, --no-recursion',
+        'short': "Don't recurse through subdirectories.",
+        'long': "The optional '-nr' or '--no-recursion' switch argument "
+                "tells the application not to scan recursively through the subdirectories."
+                'Common argument for counting and searching by extension '
+                'or counting the total number of files.'
+    },
+    'case-sensitive': {
+        'name': '-c, --case-sensitive',
+        'short': 'Treat file extensions with case sensitiveness.',
+        'long': 'The names of extensions are case insensitive by default. '
+                'The results for ini and INI will be the same. '
+                'To distinguish between similar extensions in different cases, '
+                'use the -c or --case-sensitive switch argument.'
+                'Common argument for counting and searching by extension '
+                'or counting the total number of files.'
+    },
+    'no-feedback': {
+        'name': '-nf, --no-feedback',
+        'short': "Turns off the program's operating indicator (printing processed file names in one line).",
+        'long': "Don't show the program's operating indicator (printing processed file names in one line). "
+                'Feedback is available by default for counting files by extension '
+                '(table) and for counting the total number of files (-t or --total). '
+                'This option disables it. '
+                'For searching by extension feedback is a list of the found file paths.'
+    },
+    'total-group': {
+        'name': 'Total number of files',
+        'short': 'Displaying the number of files that either have a certain extension or no extension at all. '
+                 'Usage: count-files [-a, --all] [-c, --case-sensitive] '
+                 '[-nr, --no-recursion] [-nf, --no-feedback] '
+                 '[-t EXTENSION, --total EXTENSION] [path].',
+        'long': 'Displaying the number of files that either have a certain extension or no extension at all. '
+                'To count the total number of files, '
+                'the number of files with a specific extension '
+                'or the number of files without any extension '
+                'you can use the -t or --total argument and specify the name of the extension. '
+                'Usage: count-files [-a, --all] [-c, --case-sensitive] '
+                '[-nr, --no-recursion] [-nf, --no-feedback] '
+                '[-t EXTENSION, --total EXTENSION] [path].'
+    },
+    'total': {
+        'name': '-t EXTENSION, --total EXTENSION',
+        'short': 'Get the total number of files in the directory. Specify the extension name.',
+        'long': 'Get the total number of files in the directory. Specify the extension name.'
+                'If you only need the total number of all files, '
+                'or the number of files with a certain extension or without it. '
+                'To count the total number of files, you must specify the name of the extension. '
+                'Example: count-files --total txt ~/Documents <arguments>. '
+                'Use a single dot "." to get the total number of files that do not have an extension. '
+                'Example: count-files --total . ~/Documents <arguments>. '
+                'Use two dots without spaces ".." to get the total number of files, with or without a file extension. '
+                'Example: count-files --total .. ~/Documents <arguments>. '
+    },
+    'count-group': {
+        'name': 'File counting by extension',
+        'short': 'Counting all files in the specified directory, by file extension. '
+                 'By default, it displays some feedback while scanning and '
+                 'it presents a table with file extensions sorted by frequency. '
+                 'Usage: count-files [-a, --all] [-alpha, --sort-alpha] '
+                 '[-c, --case-sensitive] [-nr, --no-recursion] [-nf, --no-feedback] [path]',
+        'long': 'Counting all files in the specified directory, by file extension. '
+                'By default, it displays some feedback while scanning and '
+                'it presents a table with file extensions sorted by frequency '
+                '(e.g.: .txt, .py, .html, .css) and the total number of files found. '
+                'All file extensions in the table will be displayed in uppercase (default). '
+                'Example: count-files <arguments>. '
+                'Usage: count-files [-a, --all] [-alpha, --sort-alpha] '
+                '[-c, --case-sensitive] [-nr, --no-recursion] [-nf, --no-feedback] [path]'
+    },
+    'sort-alpha': {
+        'name': '-alpha, --sort-alpha',
+        'short': 'Sort the table alphabetically, by file extension.',
+        'long': 'By default, result of file counting by extension is a table '
+                'that lists all the file extensions found '
+                'and displays the frequency for each file extension. '
+                'To sort the extensions alphabetically, use the -alpha or --sort-alpha argument. '
+                'Example: count-files ---sort-alpha ~/Documents <arguments>.'
+    },
+    'search-group': {
+        'name': 'File searching by extension',
+        'short': 'Searching for files that have a given extension. '
+                 'By default, it presents a simple list with full file paths. '
+                 'Optionally, it may also display a short text preview for each found file. '
+                 'Usage: count-files [-a, --all] [-c, --case-sensitive] '
+                 '[-nr, --no-recursion] [-fe FILE_EXTENSION, --file-extension FILE_EXTENSION] '
+                 '[-fs, --file-sizes] [-p, --preview] [-ps PREVIEW_SIZE, --preview-size PREVIEW_SIZE] [path]',
+        'long': 'Searching for files that have a given extension. '
+                'This utility can be used to search for files that have a certain file extension '
+                '(using -fe or --file-extension) and, optionally, '
+                'display a short preview (-p or --preview) for text files. '
+                'The size of the preview text sample can be customized '
+                'by using the -ps or --preview-size argument '
+                'followed by an integer number specifying the number of characters to present. '
+                'By default, the result of a search by a certain file extension '
+                'is a list of the full paths of the files found. '
+                'If you need information about the size of the files, '
+                'use the -fs or --file-sizes argument. '
+                'Usage: count-files [-a, --all] [-c, --case-sensitive] '
+                '[-nr, --no-recursion] [-fe FILE_EXTENSION, --file-extension FILE_EXTENSION] '
+                '[-fs, --file-sizes] [-p, --preview] [-ps PREVIEW_SIZE, --preview-size PREVIEW_SIZE] [path]'
+    },
+    'file-extension': {
+        'name': '-fe FILE_EXTENSION, --file-extension FILE_EXTENSION',
+        'short': 'Search files by file extension. Specify the extension name.',
+        'long': 'Searching and listing files by extension. Specify the extension name. '
+                'Example: count-files --file-extension txt ~/Documents <arguments>. '
+                'Use a single dot "." to search for files without any extension. '
+                'Files with names such as .gitignore, Procfile, _netrc '
+                'are considered to have no extension in their name.'
+                'Example: count-files --file-extension . ~/Documents <arguments>. '
+                'Use two dots without spaces ".." to search for all files '
+                'with or without file extensions in their names. '
+                'Example: count-files --file-extension .. ~/Documents <arguments>. '
+    },
+    'preview': {
+        'name': '-p, --preview',
+        'short': 'Display a short preview (only available for text files).',
+        'long': 'Display a short preview (only for text files). '
+                'Preview is available as an option when searching files '
+                'using the -fe or --file-extension argument. '
+                'The default text preview size depends on the terminal width settings. '
+                'You can change this value by specifying the argument -ps or --preview-size '
+                'followed by an integer (the number of characters to display from each file). '
+                'Example: count-files --file-extension txt --preview ~/Documents <arguments>.'
+    },
+    'preview-size': {
+        'name': '-ps PREVIEW_SIZE, --preview-size PREVIEW_SIZE',
+        'short': 'Specify the number of characters to be displayed from each found file.',
+        'long': 'Specify the number of characters to be displayed from each found file. '
+                'Preview text files is available as an option when searching files '
+                'using the --file-extension and --preview argument. '
+                'The default text preview size depends on the terminal width settings. '
+                'You can change this value by specifying the argument -ps or --preview-size '
+                'followed by an integer (the number of characters to display from each file). '
+                'Example: count-files --file-extension txt --preview --preview-size 50 '
+                '~/Documents <arguments>.'
+    },
+    'file-sizes': {
+        'name': '-fs, --file-sizes',
+        'short': 'Show size info for each '
+                 'found file when using -fe or --file_extension. '
+                 'Additional information: total combined size and average file size.',
+        'long': 'Show size info for each '
+                'found file when using -fe or --file_extension. '
+                'Additional information: total combined size and average file size. '
+                'Example: count-files --file-extension txt --file-sizes ~/Documents <arguments>.'
+    }
+}
+
+
+# indexes for searching in help text and sorting arguments
+indexes = {
+    ('h', 'help', 'service', 'optional'):
+        [args['help']['name'], args['help']['short'],  args['help']['long']],
+    ('ah', 'args-help', 'args', 'help', 'service', 'optional'):
+        [args['args-help']['name'], args['args-help']['short'], args['args-help']['long']],
+    ('v', 'version', 'service', 'optional'):
+        [args['version']['name'], args['version']['short'], args['version']['long']],
+    ('st', 'supported-types', 'supported', 'types', 'service', 'optional'):
+        [args['supported-types']['name'], args['supported-types']['short'], args['supported-types']['long']],
+
+    ('path', 'common', 'positional'):
+        [args['path']['name'], args['path']['short'], args['path']['long']],
+    ('a', 'all', 'common', 'optional'):
+        [args['all']['name'], args['all']['short'], args['all']['long']],
+    ('nr', 'no-recursion', 'no', 'recursion', 'common', 'optional'):
+        [args['no-recursion']['name'], args['no-recursion']['short'], args['no-recursion']['long']],
+    ('c', 'case-sensitive', 'case', 'sensitive', 'common', 'optional'):
+        [args['case-sensitive']['name'], args['case-sensitive']['short'], args['case-sensitive']['long']],
+    ('nf', 'no-feedback', 'no', 'feedback', 'common', 'optional'):
+        [args['no-feedback']['name'], args['no-feedback']['short'], args['no-feedback']['long']],
+
+    ('total-group', 'groups', 'total', 'group', 'tg'):
+        [args['total-group']['name'], args['total-group']['short'], args['total-group']['long']],
+    ('t', 'total', 'extension', 'special', 'optional'):
+        [args['total']['name'], args['total']['short'], args['total']['long']],
+
+    ('count-group', 'groups', 'count', 'group', 'cg'):
+        [args['count-group']['name'], args['count-group']['short'], args['count-group']['long']],
+    ('alpha', 'sort-alpha', 'count', 'special', 'optional'):
+        [args['sort-alpha']['name'], args['sort-alpha']['short'], args['sort-alpha']['long']],
+
+    ('search-group', 'groups', 'search', 'group', 'sg'):
+        [args['search-group']['name'], args['search-group']['short'], args['search-group']['long']],
+    ('fe', 'file-extension', 'file', 'extension', 'search', 'special', 'optional'):
+        [args['file-extension']['name'], args['file-extension']['short'], args['file-extension']['long']],
+    ('p', 'preview', 'search', 'special', 'optional'):
+        [args['preview']['name'], args['preview']['short'], args['preview']['long']],
+    ('ps', 'preview-size', 'preview', 'size', 'search', 'special', 'optional'):
+        [args['preview-size']['name'], args['preview-size']['short'], args['preview-size']['long']],
+    ('fs', 'file-sizes', 'file', 'sizes', 'search', 'special', 'optional'):
+        [args['file-sizes']['name'], args['file-sizes']['short'], args['file-sizes']['long']]
+}
+
+
+if __name__ == '__main__':
+    pass

--- a/tests/performance_tests/cprofile_test.py
+++ b/tests/performance_tests/cprofile_test.py
@@ -43,11 +43,15 @@ if __name__ == "__main__":
     # cProfile.run("main_flow([location, '-a', '-fe', 'txt'])", sort='name')
 
     # Counter and count all files with all extensions, return table, feedback - file names
-    """cProfile.run("data = count_files_by_extension(dirpath=location, no_feedback=False,"
-                 "recursive=True, include_hidden=True); show_2columns(data.most_common())", sort='name')
+    """cProfile.run("data = count_files_by_extension("
+                 "dirpath=location, no_feedback=False, recursive=True, include_hidden=False);"
+                 "total_occurrences = sum(data.values());"
+                 "max_word_width = max(map(len, data.keys()));"
+                 "data = data.most_common();"
+                 "show_2columns(data, max_word_width, total_occurrences)", sort='name')"""
 
     # generator and search all files with all extensions, return list, feedback - list itself
-    cProfile.run("data = (f for f in search_files(dirpath=location, extension='..', "
+    """cProfile.run("data = (f for f in search_files(dirpath=location, extension='..', "
                  "recursive=True, include_hidden=True, case_sensitive=False));"
                  "len_files = show_result_for_search_files(files=data, "
                  "file_sizes=False, no_feedback=False, preview=False)",
@@ -59,6 +63,3 @@ if __name__ == "__main__":
     # lists
     # cProfile.run("main_flow([location, '-fe', '.', '-fs', '-a'])", sort='name')
     # cProfile.run("main_flow([location, '-fe', '.', '-a'])", sort='name')
-
-    # win optimization, skipping hidden root folders
-    cProfile.run("main_flow([location, '-fe', '.'])", sort='name')

--- a/tests/performance_tests/timeit_test.py
+++ b/tests/performance_tests/timeit_test.py
@@ -11,6 +11,7 @@ import os
 from count_files.utils.file_handlers import search_files, count_files_by_extension
 from count_files.__main__ import main_flow
 from count_files.utils.file_handlers import get_total, get_total_by_extension
+from count_files.utils.viewing_modes import show_2columns
 
 
 def get_locations(*args):
@@ -45,8 +46,12 @@ recursive=True)
 print('Result:', len(list(r)))
 """
 
-win_optim_test = """
-main_flow([location, '-fe', '.'])
+count_by_extension = """
+data = count_files_by_extension(dirpath=location, no_feedback=False, recursive=True, include_hidden=False)
+total_occurrences = sum(data.values())
+max_word_width = max(map(len, data.keys()))
+data = data.most_common()
+show_2columns(data, max_word_width, total_occurrences)
 """
 
 
@@ -61,10 +66,11 @@ if __name__ == "__main__":
         # specify folder
         pass
 
-    # win optimization, skipping hidden root folders
-    t = timeit.Timer(win_optim_test, globals=globals())
-    print(win_optim_test, t.repeat(repeat=3, number=1))
+    # t = timeit.Timer(count_by_extension, globals=globals())
+    # print(count_by_extension, t.repeat(repeat=3, number=1))
+
     # t = timeit.Timer(total_by_extension, globals=globals())
     # print(total_by_extension, t.repeat(repeat=3, number=1))
+
     # t = timeit.Timer(main_fe, globals=globals())
     # print(main_fe, t.repeat(repeat=3, number=1))

--- a/tests/test_some_functions.py
+++ b/tests/test_some_functions.py
@@ -30,8 +30,9 @@ class TestSomeFunctions(unittest.TestCase):
             with self.subTest(k=k, v=v):
                 self.assertEqual(get_file_extension(k, case_sensitive=True), v)
 
+    # test case_sensitive param (search, count, total)
     def test_search_files_case_sensitive(self):
-        """Testing def search_files, case_sensitive param.
+        """Testing def search_files, case_sensitive param. For all OS.
 
         :return:
         if not case_sensitive: returns a list with all found files(txt, TXT, Txt and so on).
@@ -50,6 +51,121 @@ class TestSomeFunctions(unittest.TestCase):
         self.assertEqual(len(c), 1)
         self.assertEqual(len(d), 2)
 
+    def test_count_files_by_extension_case_sensitive(self):
+        """Testing def count_files_by_extension, case_sensitive and recursive params. For all OS.
+
+        Expected behavior: return object <class 'collections.Counter'>
+        :return:
+        """
+        counter = Counter({'TXT': 2, 'HTML': 1, 'MD': 1, '[no extension]': 1, 'PY': 1})
+        counter1 = Counter({'gz': 3, 'txt': 2, 'md': 2, '[no extension]': 2, 'py': 2,
+                           'TXT': 1, 'html': 1, 'json': 1, 'css': 1, 'woff': 1})
+        result = count_files_by_extension(self.get_locations('data_for_tests'), no_feedback=True,
+                                          recursive=False, include_hidden=False, case_sensitive=False)
+        result1 = count_files_by_extension(self.get_locations('data_for_tests'), no_feedback=True,
+                                           recursive=True, include_hidden=False, case_sensitive=True)
+        self.assertEqual(result, counter)
+        self.assertEqual(result1, counter1)
+
+    def test_get_total_by_extension_case_sensitive(self):
+        """Testing def get_total_by_extension with case_sensitive param. For all OS.
+
+        Expected behavior: get the total number of all files with a certain extension or without it.
+        'data_for_tests' folder does not contain hidden folders and files.
+        :return:
+        """
+        result = get_total_by_extension(dirpath=self.get_locations('data_for_tests'),
+                                        extension='txt', case_sensitive=False,
+                                        include_hidden=False, no_feedback=True, recursive=True)
+        result_nr = get_total_by_extension(dirpath=self.get_locations('data_for_tests'),
+                                           extension='TXT', case_sensitive=True,
+                                           include_hidden=False, no_feedback=True, recursive=True)
+        self.assertEqual(len(list(result)), 3)
+        self.assertEqual(len(list(result_nr)), 1)
+
+    # tests for is_hidden_file_or_dir()
+    @unittest.skipUnless(sys.platform.startswith('win'), 'for Windows')
+    def test_is_hidden_file_or_dir_win(self):
+        """Testing def is_hidden_file_or_dir.
+
+        Checking the presence of FILE_ATTRIBUTE_HIDDEN for file or folder.
+        Expected behavior: if any part of filepath(parent folders, final file/folder) is hidden return True
+        :return:
+        """
+        self.assertEqual(is_hidden_file_or_dir(
+            self.get_locations('test_hidden_windows', 'folder_hidden_for_win')), True)
+        self.assertEqual(is_hidden_file_or_dir(
+            self.get_locations('test_hidden_windows', 'not_nidden_folder')), False)
+        self.assertEqual(is_hidden_file_or_dir(
+            self.get_locations('test_hidden_windows', 'not_nidden_folder', 'hidden_for_win.xlsx')), True)
+        self.assertEqual(is_hidden_file_or_dir(
+            self.get_locations('test_hidden_windows', 'folder_hidden_for_win', 'not_hidden.py')), True)
+        self.assertEqual(is_hidden_file_or_dir(
+            self.get_locations('os_file', '0-NonPersonalRecommendations-https∺∯∯next-services.apps.microsoft.com'
+                                          '∯search∯6.3.9600-0∯776∯ru-RU_en-US.en.uk.ru∯c∯UA∯cp∯10005001∯'
+                                          'BrowseLists∯lts∯5.3.4∯cid∯0∯pc∯0∯pt∯x64∯af∯0∯lf∯1.dat')), False)
+
+    @unittest.skipUnless(sys.platform.startswith('linux')
+                         or sys.platform.startswith('darwin'), 'for Linux, Mac OS')
+    def test_is_hidden_file_or_dir_lin_mac(self):
+        """Testing def is_hidden_file_or_dir.
+
+        Check for the presence of a '/.' in the path.
+        Expected behavior: if any part of filepath(parent folders, final file/folder) is hidden return True
+        :return:
+        """
+        self.assertEqual(is_hidden_file_or_dir(
+            self.get_locations('test_hidden_linux', '.ebookreader')), True)
+        self.assertEqual(is_hidden_file_or_dir(
+            self.get_locations('test_hidden_linux', 'not_hidden_folder')), False)
+        self.assertEqual(is_hidden_file_or_dir(
+            self.get_locations('test_hidden_linux', 'not_hidden_folder', '.hidden_for_linux')), True)
+        self.assertEqual(is_hidden_file_or_dir(
+            self.get_locations('test_hidden_linux', '.ebookreader', 'not_hidden.txt')), True)
+
+    # delete?
+    def test_get_total(self):
+        """Testing def get_total with recursive param. For all OS.
+
+        Expected behavior: get the total number of all files in directory(all extensions '..').
+        'data_for_tests' folder does not contain hidden folders and files.
+        :return:
+        """
+        result = get_total(dirpath=self.get_locations('data_for_tests'), include_hidden=False,
+                           no_feedback=True, recursive=True)
+        result_nr = get_total(dirpath=self.get_locations('data_for_tests'), include_hidden=False,
+                              no_feedback=True, recursive=False)
+        self.assertEqual(len(list(result)), 16)
+        self.assertEqual(len(list(result_nr)), 6)
+
+    # tests related to preview
+    # TODO
+    def test_generate_preview(self):
+        pass
+
+    def test_generic_text_preview_errors(self):
+        # win denied_result: TEXT_PREVIEW_ERROR: [Errno 13] Permission denied: 'path\to\data_for_tests'
+        denied_result = generic_text_preview(filepath=self.get_locations('data_for_tests'), max_size=1)
+        # win no_file: TEXT_PREVIEW_ERROR: [Errno 2] No such file or directory: 'path\to\data_for_tests\no'
+        no_file = generic_text_preview(filepath=self.get_locations('data_for_tests', 'no'), max_size=1)
+        # win not_implemented: TEXT_PREVIEW_ERROR: 'charmap' codec can't decode byte 0x98 in position 579:
+        # character maps to <undefined>
+        not_implemented = generic_text_preview(
+            filepath=self.get_locations('data_for_tests', 'django_staticfiles_for_test', 'admin',
+                                        'fonts', 'LICENSE.txt.gz'), max_size=1)
+        self.assertEqual('TEXT_PREVIEW_ERROR' in denied_result, True)
+        self.assertEqual('TEXT_PREVIEW_ERROR' in no_file, True)
+        self.assertEqual('TEXT_PREVIEW_ERROR' in not_implemented, True)
+
+    def test_generic_text_preview_excerpt(self):
+        empty_file = generic_text_preview(filepath=self.get_locations(
+            'data_for_tests', 'ext_in_lowercase.txt'), max_size=1)
+        excerpt_result = generic_text_preview(filepath=self.get_locations(
+            'data_for_tests', 'py_file_for_tests.py'), max_size=1)
+        self.assertEqual(empty_file, '')
+        self.assertEqual(excerpt_result, '#')
+
+    # tests related to hidden folders and files (search, count, total)
     @unittest.skipUnless(sys.platform.startswith('win'), 'for Windows')
     def test_search_files_win(self):
         """Testing def search_files, include_hidden and recursive params.
@@ -91,108 +207,152 @@ class TestSomeFunctions(unittest.TestCase):
         self.assertEqual(len(c), 1)
         self.assertEqual(len(d), 0)
 
-    def test_count_files_by_extension(self):
-        """Testing def count_files_by_extension, case_sensitive and recursive params.
+    @unittest.skipUnless(sys.platform.startswith('win'), 'for Windows')
+    def test_count_files_by_extension_win(self):
+        """Testing def count_files_by_extension, include_hidden and recursive params.
 
         Expected behavior: return object <class 'collections.Counter'>
         :return:
         """
-        counter = Counter({'TXT': 2, 'HTML': 1, 'MD': 1, '[no extension]': 1, 'PY': 1})
-        counter1 = Counter({'gz': 3, 'txt': 2, 'md': 2, '[no extension]': 2, 'py': 2,
-                           'TXT': 1, 'html': 1, 'json': 1, 'css': 1, 'woff': 1})
-        result = count_files_by_extension(self.get_locations('data_for_tests'), no_feedback=True,
-                                          recursive=False, include_hidden=False, case_sensitive=False)
-        result1 = count_files_by_extension(self.get_locations('data_for_tests'), no_feedback=True,
-                                           recursive=True, include_hidden=False, case_sensitive=True)
-        self.assertEqual(result, counter)
-        self.assertEqual(result1, counter1)
-
-    @unittest.skipUnless(sys.platform.startswith('win'), 'for Windows')
-    def test_is_hidden_file_or_dir_win(self):
-        """Testing def is_hidden_file_or_dir.
-
-        Checking the presence of FILE_ATTRIBUTE_HIDDEN for file or folder.
-        Expected behavior: if any part of filepath(parent folders, final file/folder) is hidden return True
-        :return:
-        """
-        self.assertEqual(is_hidden_file_or_dir(
-            self.get_locations('test_hidden_windows', 'folder_hidden_for_win')), True)
-        self.assertEqual(is_hidden_file_or_dir(
-            self.get_locations('test_hidden_windows', 'not_nidden_folder')), False)
-        self.assertEqual(is_hidden_file_or_dir(
-            self.get_locations('test_hidden_windows', 'not_nidden_folder', 'hidden_for_win.xlsx')), True)
-        self.assertEqual(is_hidden_file_or_dir(
-            self.get_locations('test_hidden_windows', 'folder_hidden_for_win', 'not_hidden.py')), True)
-        self.assertEqual(is_hidden_file_or_dir(
-            self.get_locations('os_file', '0-NonPersonalRecommendations-https∺∯∯next-services.apps.microsoft.com'
-                                          '∯search∯6.3.9600-0∯776∯ru-RU_en-US.en.uk.ru∯c∯UA∯cp∯10005001∯'
-                                          'BrowseLists∯lts∯5.3.4∯cid∯0∯pc∯0∯pt∯x64∯af∯0∯lf∯1.dat')), False)
+        counter = Counter({'TXT': 1, 'XLSX': 1})
+        counter1 = Counter({'txt': 2, 'py': 2, 'xlsx': 2})
+        counter2 = Counter({'TXT': 1})
+        counter3 = Counter({'txt': 2})
+        result_r = count_files_by_extension(
+            self.get_locations('test_hidden_windows'), no_feedback=True,
+            recursive=True, include_hidden=False, case_sensitive=False)
+        result_r_hidden = count_files_by_extension(
+            self.get_locations('test_hidden_windows'), no_feedback=True,
+            recursive=True, include_hidden=True, case_sensitive=True)
+        result_nr = count_files_by_extension(
+            self.get_locations('test_hidden_windows'), no_feedback=True,
+            recursive=False, include_hidden=False, case_sensitive=False)
+        result_nr_hidden = count_files_by_extension(
+            self.get_locations('test_hidden_windows'), no_feedback=True,
+            recursive=False, include_hidden=True, case_sensitive=True)
+        self.assertEqual(result_r, counter)
+        self.assertEqual(result_r_hidden, counter1)
+        self.assertEqual(result_nr, counter2)
+        self.assertEqual(result_nr_hidden, counter3)
 
     @unittest.skipUnless(sys.platform.startswith('linux')
                          or sys.platform.startswith('darwin'), 'for Linux, Mac OS')
-    def test_is_hidden_file_or_dir_lin_mac(self):
-        """Testing def is_hidden_file_or_dir.
+    def test_count_files_by_extension_lin_mac(self):
+        """Testing def count_files_by_extension, include_hidden and recursive params.
 
-        Check for the presence of a '/.' in the path.
-        Expected behavior: if any part of filepath(parent folders, final file/folder) is hidden return True
+        Expected behavior: return object <class 'collections.Counter'>
         :return:
         """
-        self.assertEqual(is_hidden_file_or_dir(
-            self.get_locations('test_hidden_linux', '.ebookreader')), True)
-        self.assertEqual(is_hidden_file_or_dir(
-            self.get_locations('test_hidden_linux', 'not_hidden_folder')), False)
-        self.assertEqual(is_hidden_file_or_dir(
-            self.get_locations('test_hidden_linux', 'not_hidden_folder', '.hidden_for_linux')), True)
-        self.assertEqual(is_hidden_file_or_dir(
-            self.get_locations('test_hidden_linux', '.ebookreader', 'not_hidden.txt')), True)
+        counter = Counter({'TXT': 2})
+        counter1 = Counter({'[no extension]': 3, 'TXT': 3})
+        counter2 = Counter({'TXT': 1})
+        counter3 = Counter({'[no extension]': 1, 'TXT': 1})
+        result_r = count_files_by_extension(
+            self.get_locations('test_hidden_linux'), no_feedback=True,
+            recursive=True, include_hidden=False, case_sensitive=False)
+        result_r_hidden = count_files_by_extension(
+            self.get_locations('test_hidden_linux'), no_feedback=True,
+            recursive=True, include_hidden=True, case_sensitive=False)
+        result_nr = count_files_by_extension(
+            self.get_locations('test_hidden_linux'), no_feedback=True,
+            recursive=False, include_hidden=False, case_sensitive=False)
+        result_nr_hidden = count_files_by_extension(
+            self.get_locations('test_hidden_linux'), no_feedback=True,
+            recursive=False, include_hidden=True, case_sensitive=False)
+        self.assertEqual(result_r, counter)
+        self.assertEqual(result_r_hidden, counter1)
+        self.assertEqual(result_nr, counter2)
+        self.assertEqual(result_nr_hidden, counter3)
 
-    def test_get_total(self):
-        """Testing def get_total.
+    @unittest.skipUnless(sys.platform.startswith('win'), 'for Windows')
+    def test_get_total_win(self):
+        """Testing def get_total with include_hidden and recursive params.
 
         Expected behavior: get the total number of all files in directory(all extensions '..').
         :return:
         """
-        result = get_total(dirpath=self.get_locations('data_for_tests'), include_hidden=False,
-                           no_feedback=True, recursive=True)
-        self.assertEqual(len(list(result)), 16)
+        result_r = get_total(dirpath=self.get_locations('test_hidden_windows'),
+                             include_hidden=False, no_feedback=True, recursive=True)
+        result_r_hidden = get_total(dirpath=self.get_locations('test_hidden_windows'),
+                                    include_hidden=True, no_feedback=True, recursive=True)
+        result_nr = get_total(dirpath=self.get_locations('test_hidden_windows'),
+                              include_hidden=False, no_feedback=True, recursive=False)
+        result_nr_hidden = get_total(dirpath=self.get_locations('test_hidden_windows'),
+                                     include_hidden=True, no_feedback=True, recursive=False)
+        self.assertEqual(len(list(result_r)), 2)
+        self.assertEqual(len(list(result_r_hidden)), 6)
+        self.assertEqual(len(list(result_nr)), 1)
+        self.assertEqual(len(list(result_nr_hidden)), 2)
 
-    def test_get_total_by_extension(self):
-        """Testing def get_total_by_extension.
+    @unittest.skipUnless(sys.platform.startswith('linux')
+                         or sys.platform.startswith('darwin'), 'for Linux, Mac OS')
+    def test_get_total_lin_mac(self):
+        """Testing def get_total with include_hidden and recursive params.
+
+        Expected behavior: get the total number of all files in directory(all extensions '..').
+        :return:
+        """
+        result_r = get_total(dirpath=self.get_locations('test_hidden_linux'),
+                             include_hidden=False, no_feedback=True, recursive=True)
+        result_r_hidden = get_total(dirpath=self.get_locations('test_hidden_linux'),
+                                    include_hidden=True, no_feedback=True, recursive=True)
+        result_nr = get_total(dirpath=self.get_locations('test_hidden_linux'),
+                              include_hidden=False, no_feedback=True, recursive=False)
+        result_nr_hidden = get_total(dirpath=self.get_locations('test_hidden_linux'),
+                                     include_hidden=True, no_feedback=True, recursive=False)
+        self.assertEqual(len(list(result_r)), 2)
+        self.assertEqual(len(list(result_r_hidden)), 6)
+        self.assertEqual(len(list(result_nr)), 1)
+        self.assertEqual(len(list(result_nr_hidden)), 2)
+
+    @unittest.skipUnless(sys.platform.startswith('win'), 'for Windows')
+    def test_get_total_by_extension_win(self):
+        """Testing def get_total_by_extension with include_hidden and recursive params.
 
         Expected behavior: get the total number of all files with a certain extension or without it.
         :return:
         """
-        result = get_total_by_extension(dirpath=self.get_locations('data_for_tests'),
-                                        extension='.', case_sensitive=False,
-                                        include_hidden=False, no_feedback=True, recursive=True)
-        self.assertEqual(len(list(result)), 2)
+        result_r = get_total_by_extension(dirpath=self.get_locations('test_hidden_windows'),
+                                          extension='py', case_sensitive=False,
+                                          include_hidden=False, no_feedback=True, recursive=True)
+        result_r_hidden = get_total_by_extension(dirpath=self.get_locations('test_hidden_windows'),
+                                                 extension='py', case_sensitive=False,
+                                                 include_hidden=True, no_feedback=True, recursive=True)
+        result_nr = get_total_by_extension(dirpath=self.get_locations('test_hidden_windows'),
+                                           extension='txt', case_sensitive=False,
+                                           include_hidden=False, no_feedback=True, recursive=False)
+        result_nr_hidden = get_total_by_extension(dirpath=self.get_locations('test_hidden_windows'),
+                                                  extension='txt', case_sensitive=False,
+                                                  include_hidden=True, no_feedback=True, recursive=False)
+        self.assertEqual(len(list(result_r)), 0)
+        self.assertEqual(len(list(result_r_hidden)), 2)
+        self.assertEqual(len(list(result_nr)), 1)
+        self.assertEqual(len(list(result_nr_hidden)), 2)
 
-    # TODO
-    def test_generate_preview(self):
-        pass
+    @unittest.skipUnless(sys.platform.startswith('linux')
+                         or sys.platform.startswith('darwin'), 'for Linux, Mac OS')
+    def test_get_total_by_extension_lin_mac(self):
+        """Testing def get_total_by_extension with include_hidden and recursive params.
 
-    def test_generic_text_preview_errors(self):
-        # win denied_result: TEXT_PREVIEW_ERROR: [Errno 13] Permission denied: 'path\to\data_for_tests'
-        denied_result = generic_text_preview(filepath=self.get_locations('data_for_tests'), max_size=1)
-        # win no_file: TEXT_PREVIEW_ERROR: [Errno 2] No such file or directory: 'path\to\data_for_tests\no'
-        no_file = generic_text_preview(filepath=self.get_locations('data_for_tests', 'no'), max_size=1)
-        # win not_implemented: TEXT_PREVIEW_ERROR: 'charmap' codec can't decode byte 0x98 in position 579:
-        # character maps to <undefined>
-        not_implemented = generic_text_preview(
-            filepath=self.get_locations('data_for_tests', 'django_staticfiles_for_test', 'admin',
-                                        'fonts', 'LICENSE.txt.gz'), max_size=1)
-        self.assertEqual('TEXT_PREVIEW_ERROR' in denied_result, True)
-        self.assertEqual('TEXT_PREVIEW_ERROR' in no_file, True)
-        self.assertEqual('TEXT_PREVIEW_ERROR' in not_implemented, True)
-
-    def test_generic_text_preview_excerpt(self):
-        empty_file = generic_text_preview(filepath=self.get_locations(
-            'data_for_tests', 'ext_in_lowercase.txt'), max_size=1)
-        excerpt_result = generic_text_preview(filepath=self.get_locations(
-            'data_for_tests', 'py_file_for_tests.py'), max_size=1)
-        self.assertEqual(empty_file, '')
-        self.assertEqual(excerpt_result, '#')
-
+        Expected behavior: get the total number of all files with a certain extension or without it.
+        :return:
+        """
+        result_r = get_total_by_extension(dirpath=self.get_locations('test_hidden_linux'),
+                                          extension='txt', case_sensitive=False,
+                                          include_hidden=False, no_feedback=True, recursive=True)
+        result_r_hidden = get_total_by_extension(dirpath=self.get_locations('test_hidden_linux'),
+                                                 extension='.', case_sensitive=False,
+                                                 include_hidden=True, no_feedback=True, recursive=True)
+        result_nr = get_total_by_extension(dirpath=self.get_locations('test_hidden_linux'),
+                                           extension='txt', case_sensitive=False,
+                                           include_hidden=False, no_feedback=True, recursive=False)
+        result_nr_hidden = get_total_by_extension(dirpath=self.get_locations('test_hidden_linux'),
+                                                  extension='txt', case_sensitive=False,
+                                                  include_hidden=True, no_feedback=True, recursive=False)
+        self.assertEqual(len(list(result_r)), 2)
+        self.assertEqual(len(list(result_r_hidden)), 3)
+        self.assertEqual(len(list(result_nr)), 1)
+        self.assertEqual(len(list(result_nr_hidden)), 1)
 
 # from root directory:
 


### PR DESCRIPTION
- added help system extension(search in the help text)
added new `-ah/--args-help` argument
added documentation url in settings
Search in help by keyword - argument or group name, search words.
Searching in help text or sorting arguments using indexes and argument/group names descriptions (short and long help text).
Show more detailed help text about `--args-help` argument:  `count-files -ah docs`.
- ordering old tests
Nothing changed.
