### PR TITLE
Changed Parser total_group, replace get_total and get_total_by_ext with search_files.

### DIFF
--- a/count_files/__main__.py
+++ b/count_files/__main__.py
@@ -26,10 +26,9 @@ from typing import TypeVar, Union
 from pathlib import Path
 from textwrap import fill
 
-from count_files.utils.file_handlers import count_files_by_extension, search_files, \
-    get_total, get_total_by_extension
+from count_files.utils.file_handlers import count_files_by_extension, search_files
 from count_files.utils.file_handlers import is_hidden_file_or_dir, is_supported_filetype
-from count_files.utils.viewing_modes import show_2columns, show_start_message
+from count_files.utils.viewing_modes import show_2columns, show_start_message, show_result_for_total
 from count_files.utils.viewing_modes import show_result_for_search_files
 from count_files.settings import not_supported_type_message, supported_type_info_message, \
     DEFAULT_PREVIEW_SIZE, START_TEXT_WIDTH
@@ -155,29 +154,19 @@ def main_flow(*args: [argparse_namespace_object, Union[bytes, str]]):
                                           f'Use the --all argument to include hidden files and folders.')
 
     # Parser total_group
-    # getting the total number of files for -fe .. (all extensions), -fe . and -fe extension_name
+    # getting the total number of files for -t .. (all extensions), -t . and -t extension_name
     print("")
     if args.extension:
-        print(fill(show_start_message(args.extension, args.case_sensitive, recursive, include_hidden, location, 'total'),
+        print(fill(show_start_message(args.extension, args.case_sensitive, recursive,
+                                      include_hidden, location, 'total'),
                    width=START_TEXT_WIDTH),
-              end="\n\n"
-              )
-        if args.extension == '..':
-            result = get_total(dirpath=location,
-                               include_hidden=include_hidden,
-                               no_feedback=args.no_feedback,
-                               recursive=recursive)
-        else:
-            result = get_total_by_extension(dirpath=location,
-                                            extension=args.extension,
-                                            case_sensitive=args.case_sensitive,
-                                            include_hidden=include_hidden,
-                                            no_feedback=args.no_feedback,
-                                            recursive=recursive)
-        # var for tests
-        total_result = len(list(result))
-        print(f'   Found {total_result} file(s).',
               end="\n\n")
+        data = search_files(dirpath=location,
+                            extension=args.extension,
+                            include_hidden=include_hidden,
+                            recursive=recursive,
+                            case_sensitive=args.case_sensitive)
+        total_result = show_result_for_total(data, args.no_feedback)
         return total_result
 
     # Parser search_group

--- a/count_files/utils/file_handlers.py
+++ b/count_files/utils/file_handlers.py
@@ -240,13 +240,15 @@ def get_total_by_extension(dirpath: str, extension: str, case_sensitive: bool = 
         for f in files:
             if not no_feedback:
                 print("\r" + f[:TERM_WIDTH - 1].ljust(TERM_WIDTH - 1), end="")
+            # first check ext
+            if get_file_extension(f, case_sensitive) != ext:
+                continue
+            # then hidden/not hidden
             if include_hidden:
-                if get_file_extension(f, case_sensitive) == ext:
-                    yield f
+                yield f
             else:
                 if not is_hidden_file_or_dir(os.path.join(root, f)):
-                    if get_file_extension(f, case_sensitive) == ext:
-                        yield f
+                    yield f
         if not recursive:
             break
     if not no_feedback:

--- a/count_files/utils/file_handlers.py
+++ b/count_files/utils/file_handlers.py
@@ -69,9 +69,9 @@ def search_files(dirpath: str, extension: str, recursive: bool = True,
     :param include_hidden: False -> exclude hidden, True -> include hidden, counting all files
     :param case_sensitive: False -> ignore case in extensions,
     True -> distinguish case variations in extensions
-    :return: object <class 'generator'>
+    :return: object <class 'generator'> with full paths to all found files
     """
-    # this part used for -fe .. (all extensions)
+    # this part used for -fe .. or -t .. (all extensions)
     if extension == '..':
         for root, dirs, files in os.walk(dirpath):
             for f in files:
@@ -82,15 +82,14 @@ def search_files(dirpath: str, extension: str, recursive: bool = True,
                     yield f_path
             if not recursive:
                 break
-    # this part used for -fe . and -fe extension_name
+    # this part used for: -fe . or -fe extension_name, -t . or -t extension_name
     else:
+        ext = extension if case_sensitive else extension.upper()
         for root, dirs, files in os.walk(dirpath):
             for f in files:
-                if not case_sensitive:
-                    extension = extension.upper()
                 f_path = os.path.join(root, f)
                 f_extension = get_file_extension(f_path, case_sensitive=case_sensitive)
-                if f_extension != extension or not os.path.isfile(f_path):
+                if f_extension != ext or not os.path.isfile(f_path):
                     continue
                 if include_hidden or not is_hidden_file_or_dir(f_path):
                     yield f_path
@@ -194,62 +193,3 @@ def is_hidden_file_or_dir(filepath: str) -> bool:
         return bool('/.' in filepath)
     elif platform_name.startswith('darwin') or platform_name.startswith('ios'):
         return bool('/.' in filepath)
-
-
-def get_total(dirpath: str, include_hidden: bool = False,
-              no_feedback: bool = False,
-              recursive: bool = True) -> Iterable[str]:
-    """Get the total number of all files in directory(all extensions '..').
-
-    :param dirpath: full/path/to/folder
-    :param recursive: True(default, recursive search/count) or False
-    :param include_hidden: False -> exclude hidden(default), True -> include hidden files and dirs
-    :param no_feedback: True or False(default, prints processed file names in one line)
-    :return: object <class 'generator'>
-    """
-    for root, dirs, files in os.walk(dirpath):
-        for f in files:
-            if not no_feedback:
-                print("\r" + f[:TERM_WIDTH - 1].ljust(TERM_WIDTH - 1), end="")
-            if include_hidden:
-                yield f
-            else:
-                if not is_hidden_file_or_dir(os.path.join(root, f)):
-                    yield f
-        if not recursive:
-            break
-    if not no_feedback:
-        print("\r".ljust(TERM_WIDTH - 1))  # Clean the feedback text before proceeding.
-
-
-def get_total_by_extension(dirpath: str, extension: str, case_sensitive: bool = False,
-                           include_hidden: bool = False, no_feedback: bool = False,
-                           recursive: bool = True) -> Iterable[str]:
-    """Get the total number of all files with a certain extension or without it.
-
-    :param dirpath: full/path/to/folder
-    :param extension: extension name (txt, py) or '.'(without extension)
-    :param recursive: True(default, recursive search/count) or False
-    :param include_hidden: False -> exclude hidden(default), True -> include hidden files and dirs
-    :param no_feedback: True or False(default, prints processed file names in one line)
-    :param case_sensitive: False -> ignore case in extensions, True -> distinguish case variations in extensions
-    :return: object <class 'generator'>
-    """
-    ext = extension if case_sensitive else extension.upper()
-    for root, dirs, files in os.walk(dirpath):
-        for f in files:
-            if not no_feedback:
-                print("\r" + f[:TERM_WIDTH - 1].ljust(TERM_WIDTH - 1), end="")
-            # first check ext
-            if get_file_extension(f, case_sensitive) != ext:
-                continue
-            # then hidden/not hidden
-            if include_hidden:
-                yield f
-            else:
-                if not is_hidden_file_or_dir(os.path.join(root, f)):
-                    yield f
-        if not recursive:
-            break
-    if not no_feedback:
-        print("\r".ljust(TERM_WIDTH - 1))  # Clean the feedback text before proceeding.

--- a/count_files/utils/viewing_modes.py
+++ b/count_files/utils/viewing_modes.py
@@ -73,8 +73,9 @@ def show_result_for_search_files(files: Iterable[str],
     :param file_sizes: True -> show size info, False -> don't show size info
     :param preview: optional, args.preview, True or False
     :param preview_size: optional, args.preview_size, number
-    :return: len(files), print list with paths(default)
-                                  if file_sizes:
+    :return: len(files), print list with paths(default),
+    get preview and file_sizes if specified.
+
     full/path/to/file1.extension (... KiB)
     –––––––––––––––––––––––––––––––––––
     preview, if preview=True and supported type
@@ -158,3 +159,25 @@ def show_start_message(value: [None, str], case_sensitive: bool, recursive: bool
               f'{h if include_hidden else nh}, in {location}'
 
     return message
+
+
+def show_result_for_total(files: Iterable[str], no_feedback: bool) -> int:
+    """Print feedback and total number of all found file paths for Parser total_group.
+
+    :param files: object <class 'generator'> with full paths to all found files
+    :param no_feedback: True or False(default, prints processed file paths in one line)
+    :return: len(files), files amount
+    """
+    if not no_feedback:
+        files_amount = 0
+        for f in files:
+            files_amount += 1
+            print("\r" + f[:TERM_WIDTH - 1].ljust(TERM_WIDTH - 1), end="")
+        print("\r".ljust(TERM_WIDTH))  # Clean the feedback text before proceeding.
+    else:
+        files_amount = len(list(files))
+    if files_amount == 0:
+        print(f"No files were found in the specified directory.\n")
+    else:
+        print(f'   Found {files_amount} file(s).', end="\n\n")
+    return files_amount

--- a/tests/performance_tests/cprofile_test.py
+++ b/tests/performance_tests/cprofile_test.py
@@ -17,7 +17,7 @@ import cProfile
 import os
 import sys
 
-from count_files.utils.viewing_modes import show_result_for_search_files, show_2columns
+from count_files.utils.viewing_modes import show_result_for_search_files, show_2columns, show_result_for_total
 from count_files.utils.file_handlers import search_files, count_files_by_extension
 from count_files.__main__ import main_flow
 
@@ -37,11 +37,6 @@ if __name__ == "__main__":
         # specify folder
         pass
 
-    # count all files
-    # cProfile.run("main_flow([location, '-a'])", sort='name')
-    # if extension thread, search for txt extension
-    # cProfile.run("main_flow([location, '-a', '-fe', 'txt'])", sort='name')
-
     # Counter and count all files with all extensions, return table, feedback - file names
     """cProfile.run("data = count_files_by_extension("
                  "dirpath=location, no_feedback=False, recursive=True, include_hidden=False);"
@@ -50,16 +45,26 @@ if __name__ == "__main__":
                  "data = data.most_common();"
                  "show_2columns(data, max_word_width, total_occurrences)", sort='name')"""
 
-    # generator and search all files with all extensions, return list, feedback - list itself
+    # generator and search files, return list, feedback - list itself
     """cProfile.run("data = (f for f in search_files(dirpath=location, extension='..', "
                  "recursive=True, include_hidden=True, case_sensitive=False));"
                  "len_files = show_result_for_search_files(files=data, "
-                 "file_sizes=False, no_feedback=False, preview=False)",
+                 "file_sizes=False, preview=False)",
                  sort='name')"""
 
-    # total number of files
-    # cProfile.run("main_flow([location, '-t', '..', '-a'])", sort='name')
+    # generator and get total files, return list, feedback - file paths
+    """cProfile.run("data = search_files(dirpath=location, extension='..', "
+                 "recursive=True, include_hidden=True, case_sensitive=False);"
+                 "len_files = show_result_for_total(files=data, "
+                 "no_feedback=False)",
+                 sort='name')"""
 
-    # lists
-    # cProfile.run("main_flow([location, '-fe', '.', '-fs', '-a'])", sort='name')
-    # cProfile.run("main_flow([location, '-fe', '.', '-a'])", sort='name')
+    # count
+    # cProfile.run("main_flow([location])", sort='name')
+
+    # search
+    # cProfile.run("main_flow([location, '-fe', '..'])", sort='name')
+
+    # total
+    # cProfile.run("main_flow([location, '-t', '..'])", sort='name')
+

--- a/tests/performance_tests/timeit_test.py
+++ b/tests/performance_tests/timeit_test.py
@@ -11,39 +11,29 @@ import os
 from count_files.utils.file_handlers import search_files, count_files_by_extension
 from count_files.__main__ import main_flow
 from count_files.utils.file_handlers import get_total, get_total_by_extension
-from count_files.utils.viewing_modes import show_2columns
+from count_files.utils.viewing_modes import show_2columns, show_result_for_total, show_result_for_search_files
 
 
 def get_locations(*args):
     return os.path.normpath(os.path.join(os.path.expanduser('~/'), *args))
 
 
+main_c = """
+main_flow([location])
+"""
+
 main_fe = """
-main_flow([location, '-a', '-fe', 'txt'])
+main_flow([location, '-fe', 'txt'])
 """
 
-main_fe_fs = """
-main_flow([location, '-a', '-fe', 'txt', '-fs'])
+main_t = """
+main_flow([location, '-t', 'txt'])
 """
 
-search_files_feedback = """
-data = (f for f in search_files(dirpath=location, extension='.', recursive=True, include_hidden=True, case_sensitive=False))
-"""
-
-count_files_feedback = """
-data = count_files_by_extension(dirpath=location, no_feedback=False, recursive=True, include_hidden=True)
-"""
-
-total = """
-r = get_total(location, include_hidden=True, no_feedback=False, recursive=True)
-print('Result:', len(list(r)))
-"""
-
-total_by_extension = """
-r = get_total_by_extension(location, extension='txt',
-case_sensitive=False, include_hidden=True, no_feedback=False,
-recursive=True)
-print('Result:', len(list(r)))
+search_by_extension = """
+data = (f for f in search_files(dirpath=location, extension='..',
+recursive=True, include_hidden=True, case_sensitive=False))
+len_files = show_result_for_search_files(files=data, file_sizes=False, preview=False)
 """
 
 count_by_extension = """
@@ -52,6 +42,12 @@ total_occurrences = sum(data.values())
 max_word_width = max(map(len, data.keys()))
 data = data.most_common()
 show_2columns(data, max_word_width, total_occurrences)
+"""
+
+total_and_extension = """
+data = search_files(dirpath=location, extension='..',
+recursive=True, include_hidden=True, case_sensitive=False)
+len_files = show_result_for_total(files=data, no_feedback=False)
 """
 
 
@@ -66,11 +62,8 @@ if __name__ == "__main__":
         # specify folder
         pass
 
+    # t = timeit.Timer(main_t, globals=globals())
+    # print(main_t, t.repeat(repeat=3, number=1))
+
     # t = timeit.Timer(count_by_extension, globals=globals())
     # print(count_by_extension, t.repeat(repeat=3, number=1))
-
-    # t = timeit.Timer(total_by_extension, globals=globals())
-    # print(total_by_extension, t.repeat(repeat=3, number=1))
-
-    # t = timeit.Timer(main_fe, globals=globals())
-    # print(main_fe, t.repeat(repeat=3, number=1))

--- a/tests/test_some_functions.py
+++ b/tests/test_some_functions.py
@@ -5,8 +5,7 @@ import sys
 from collections import Counter
 
 from count_files.utils.file_handlers import get_file_extension,\
-    is_hidden_file_or_dir, search_files, count_files_by_extension,\
-    get_total, get_total_by_extension
+    is_hidden_file_or_dir, search_files, count_files_by_extension
 from count_files.utils.file_preview import generate_preview, generic_text_preview
 
 
@@ -67,22 +66,6 @@ class TestSomeFunctions(unittest.TestCase):
         self.assertEqual(result, counter)
         self.assertEqual(result1, counter1)
 
-    def test_get_total_by_extension_case_sensitive(self):
-        """Testing def get_total_by_extension with case_sensitive param. For all OS.
-
-        Expected behavior: get the total number of all files with a certain extension or without it.
-        'data_for_tests' folder does not contain hidden folders and files.
-        :return:
-        """
-        result = get_total_by_extension(dirpath=self.get_locations('data_for_tests'),
-                                        extension='txt', case_sensitive=False,
-                                        include_hidden=False, no_feedback=True, recursive=True)
-        result_nr = get_total_by_extension(dirpath=self.get_locations('data_for_tests'),
-                                           extension='TXT', case_sensitive=True,
-                                           include_hidden=False, no_feedback=True, recursive=True)
-        self.assertEqual(len(list(result)), 3)
-        self.assertEqual(len(list(result_nr)), 1)
-
     # tests for is_hidden_file_or_dir()
     @unittest.skipUnless(sys.platform.startswith('win'), 'for Windows')
     def test_is_hidden_file_or_dir_win(self):
@@ -122,21 +105,6 @@ class TestSomeFunctions(unittest.TestCase):
             self.get_locations('test_hidden_linux', 'not_hidden_folder', '.hidden_for_linux')), True)
         self.assertEqual(is_hidden_file_or_dir(
             self.get_locations('test_hidden_linux', '.ebookreader', 'not_hidden.txt')), True)
-
-    # delete?
-    def test_get_total(self):
-        """Testing def get_total with recursive param. For all OS.
-
-        Expected behavior: get the total number of all files in directory(all extensions '..').
-        'data_for_tests' folder does not contain hidden folders and files.
-        :return:
-        """
-        result = get_total(dirpath=self.get_locations('data_for_tests'), include_hidden=False,
-                           no_feedback=True, recursive=True)
-        result_nr = get_total(dirpath=self.get_locations('data_for_tests'), include_hidden=False,
-                              no_feedback=True, recursive=False)
-        self.assertEqual(len(list(result)), 16)
-        self.assertEqual(len(list(result_nr)), 6)
 
     # tests related to preview
     # TODO
@@ -264,95 +232,6 @@ class TestSomeFunctions(unittest.TestCase):
         self.assertEqual(result_nr, counter2)
         self.assertEqual(result_nr_hidden, counter3)
 
-    @unittest.skipUnless(sys.platform.startswith('win'), 'for Windows')
-    def test_get_total_win(self):
-        """Testing def get_total with include_hidden and recursive params.
-
-        Expected behavior: get the total number of all files in directory(all extensions '..').
-        :return:
-        """
-        result_r = get_total(dirpath=self.get_locations('test_hidden_windows'),
-                             include_hidden=False, no_feedback=True, recursive=True)
-        result_r_hidden = get_total(dirpath=self.get_locations('test_hidden_windows'),
-                                    include_hidden=True, no_feedback=True, recursive=True)
-        result_nr = get_total(dirpath=self.get_locations('test_hidden_windows'),
-                              include_hidden=False, no_feedback=True, recursive=False)
-        result_nr_hidden = get_total(dirpath=self.get_locations('test_hidden_windows'),
-                                     include_hidden=True, no_feedback=True, recursive=False)
-        self.assertEqual(len(list(result_r)), 2)
-        self.assertEqual(len(list(result_r_hidden)), 6)
-        self.assertEqual(len(list(result_nr)), 1)
-        self.assertEqual(len(list(result_nr_hidden)), 2)
-
-    @unittest.skipUnless(sys.platform.startswith('linux')
-                         or sys.platform.startswith('darwin'), 'for Linux, Mac OS')
-    def test_get_total_lin_mac(self):
-        """Testing def get_total with include_hidden and recursive params.
-
-        Expected behavior: get the total number of all files in directory(all extensions '..').
-        :return:
-        """
-        result_r = get_total(dirpath=self.get_locations('test_hidden_linux'),
-                             include_hidden=False, no_feedback=True, recursive=True)
-        result_r_hidden = get_total(dirpath=self.get_locations('test_hidden_linux'),
-                                    include_hidden=True, no_feedback=True, recursive=True)
-        result_nr = get_total(dirpath=self.get_locations('test_hidden_linux'),
-                              include_hidden=False, no_feedback=True, recursive=False)
-        result_nr_hidden = get_total(dirpath=self.get_locations('test_hidden_linux'),
-                                     include_hidden=True, no_feedback=True, recursive=False)
-        self.assertEqual(len(list(result_r)), 2)
-        self.assertEqual(len(list(result_r_hidden)), 6)
-        self.assertEqual(len(list(result_nr)), 1)
-        self.assertEqual(len(list(result_nr_hidden)), 2)
-
-    @unittest.skipUnless(sys.platform.startswith('win'), 'for Windows')
-    def test_get_total_by_extension_win(self):
-        """Testing def get_total_by_extension with include_hidden and recursive params.
-
-        Expected behavior: get the total number of all files with a certain extension or without it.
-        :return:
-        """
-        result_r = get_total_by_extension(dirpath=self.get_locations('test_hidden_windows'),
-                                          extension='py', case_sensitive=False,
-                                          include_hidden=False, no_feedback=True, recursive=True)
-        result_r_hidden = get_total_by_extension(dirpath=self.get_locations('test_hidden_windows'),
-                                                 extension='py', case_sensitive=False,
-                                                 include_hidden=True, no_feedback=True, recursive=True)
-        result_nr = get_total_by_extension(dirpath=self.get_locations('test_hidden_windows'),
-                                           extension='txt', case_sensitive=False,
-                                           include_hidden=False, no_feedback=True, recursive=False)
-        result_nr_hidden = get_total_by_extension(dirpath=self.get_locations('test_hidden_windows'),
-                                                  extension='txt', case_sensitive=False,
-                                                  include_hidden=True, no_feedback=True, recursive=False)
-        self.assertEqual(len(list(result_r)), 0)
-        self.assertEqual(len(list(result_r_hidden)), 2)
-        self.assertEqual(len(list(result_nr)), 1)
-        self.assertEqual(len(list(result_nr_hidden)), 2)
-
-    @unittest.skipUnless(sys.platform.startswith('linux')
-                         or sys.platform.startswith('darwin'), 'for Linux, Mac OS')
-    def test_get_total_by_extension_lin_mac(self):
-        """Testing def get_total_by_extension with include_hidden and recursive params.
-
-        Expected behavior: get the total number of all files with a certain extension or without it.
-        :return:
-        """
-        result_r = get_total_by_extension(dirpath=self.get_locations('test_hidden_linux'),
-                                          extension='txt', case_sensitive=False,
-                                          include_hidden=False, no_feedback=True, recursive=True)
-        result_r_hidden = get_total_by_extension(dirpath=self.get_locations('test_hidden_linux'),
-                                                 extension='.', case_sensitive=False,
-                                                 include_hidden=True, no_feedback=True, recursive=True)
-        result_nr = get_total_by_extension(dirpath=self.get_locations('test_hidden_linux'),
-                                           extension='txt', case_sensitive=False,
-                                           include_hidden=False, no_feedback=True, recursive=False)
-        result_nr_hidden = get_total_by_extension(dirpath=self.get_locations('test_hidden_linux'),
-                                                  extension='txt', case_sensitive=False,
-                                                  include_hidden=True, no_feedback=True, recursive=False)
-        self.assertEqual(len(list(result_r)), 2)
-        self.assertEqual(len(list(result_r_hidden)), 3)
-        self.assertEqual(len(list(result_nr)), 1)
-        self.assertEqual(len(list(result_nr_hidden)), 1)
 
 # from root directory:
 

--- a/tests/test_viewing_modes.py
+++ b/tests/test_viewing_modes.py
@@ -14,6 +14,7 @@ class TestViewingModes(unittest.TestCase):
     """Testing viewing_modes.py functions"""
 
     def setUp(self):
+        self.test_file_total = self.get_locations('compare_tables', 'test_show_result_total.txt')
         self.test_file = self.get_locations('compare_tables', 'test_show_result_list.txt')
         if sys.platform.startswith('win'):
             self.standard_file = self.get_locations('compare_tables', 'win_show_result_list.txt')


### PR DESCRIPTION
These two functions differ only in the presentation of results, the structure itself is similar.
The execution time is about the same.
I turned feedback to a separate function, so now we can use one function for both groups.

- changed Parser total_group, replace get_total and get_total_by_ext with search_files in main.py
- added def show_result_for_total (used with def search_files)
- updated tests 