### PR TITLE
Help tables. Added def show_help_columns(displays table or list of topics). Updated tests.

### DIFF
--- a/count_files/utils/help_text.py
+++ b/count_files/utils/help_text.py
@@ -78,39 +78,8 @@ Web Docs in English, Portuguese, Russian and Ukrainian:
     https://github.com/victordomingos/Count-files#documentation
 """
 from count_files.settings import DOCUMENTATION_URL, DEFAULT_PREVIEW_SIZE
+from count_files.utils.viewing_modes import show_help_columns
 
-
-arguments = [
-    # common arguments(positional)
-    'path',
-    # service arguments(optional)
-    'h', 'help', 'ah', 'args-help', 'v', 'version', 'st', 'supported-types',
-    # common arguments(optional)
-    'a', 'all', 'c', 'case-sensitive',
-    'nr', 'no-recursion', 'nf', 'no-feedback',
-    # special arguments(optional)
-    'alpha', 'sort-alpha',
-    'fe', 'file-extension', 'fs', 'file-sizes',
-    'p', 'preview', 'ps', 'preview-size',
-    't', 'total',
-]
-
-search_words = [
-    # sorting by purpose
-    'service', 'common', 'special',
-    # sorting by argument type
-    'positional', 'optional'
-]
-
-group_names = [
-    # cg, count-group - certain group description
-    # count - sorting by group, including group description
-    'cg', 'count-group', 'count',
-    'sg', 'search-group', 'search',
-    'tg', 'total-group', 'total',
-    # all group descriptions
-    'group'
-]
 
 docs_text = f"""HELP SYSTEM EXTENSION DOCS.
 
@@ -146,10 +115,23 @@ Web Docs in English, Portuguese, Russian and Ukrainian:
     {DOCUMENTATION_URL}
 """
 
+arguments = [
+             # column titles
+             'LONG', 'SHORT',
+             # positional
+             'path', 'path',
+             # optional
+             'all', 'a', 'args-help', 'ah',
+             'case-sensitive', 'c', 'file-extension', 'fe', 'file-sizes', 'fs',
+             'help', 'h', 'no-feedback', 'nf', 'no-recursion', 'nr',
+             'preview', 'p', 'preview-size', 'ps',
+             'sort-alpha', 'alpha', 'supported-types', 'st', 'total', 't', 'version', 'v']
+
 docs_args_text = f"""HELP SYSTEM EXTENSION DOCS(ARGS).
 
 AVAILABLE ARGUMENT NAMES:
-{', '.join(arguments)}
+
+{show_help_columns(column_version=arguments, list_version=arguments[3:], num_columns=2)}
 
 SEARCH BY ARGUMENT NAME:
 Short argument name.
@@ -161,10 +143,18 @@ Partial argument name if it consists of two words.
     count-files --args-help types
 """
 
+sort_words = [
+    'SORT BY PURPOSE', 'SORT BY TYPE',
+    'service', 'positional',
+    'common', 'optional',
+    'special'
+]
+
 docs_sort_text = f"""HELP SYSTEM EXTENSION DOCS(SORT).
 
 AVAILABLE SORT WORDS:
-{', '.join(search_words)}
+
+{show_help_columns(column_version=sort_words, list_version=sorted(sort_words[2:]), num_columns=2)}
 
 SORTING ARGUMENTS BY PURPOSE:
 Service arguments: display of help, version of the program etc.
@@ -184,10 +174,22 @@ SORTING ARGUMENTS BY TYPE:
     count-files --args-help optional
 """
 
+group_names = [
+    'GROUP DESC', 'ARGS AND DESC',
+    # cg, count-group - certain group description
+    # count - sorting by group, including group description
+    'cg, count-group', 'count',
+    'sg, search-group', 'search',
+    'tg, total-group', 'total',
+    # all group descriptions
+    'group'
+]
+
 docs_groups_text = f"""HELP SYSTEM EXTENSION DOCS(GROUPS).
 
 AVAILABLE GROUP NAMES:
-{', '.join(group_names)}
+
+{show_help_columns(column_version=group_names, list_version=sorted(group_names[2:]), num_columns=2)}
 
 SORTING ARGUMENTS BY GROUP:
 Sorting arguments by group, including group description.
@@ -216,13 +218,16 @@ Web Docs in English, Portuguese, Russian and Ukrainian:
 docs_list_text = f"""HELP SYSTEM EXTENSION DOCS(LIST).
 
 AVAILABLE ARGUMENT NAMES:
-{', '.join(arguments)}
+
+{show_help_columns(column_version=arguments, list_version=arguments[3:], num_columns=2)}
 
 AVAILABLE SORT WORDS:
-{', '.join(search_words)}
+
+{show_help_columns(column_version=sort_words, list_version=sorted(sort_words[2:]), num_columns=2)}
 
 AVAILABLE GROUP NAMES:
-{', '.join(group_names)}
+
+{show_help_columns(column_version=group_names, list_version=sorted(group_names[2:]), num_columns=2)}
 
 {docs_general_text}
 """

--- a/count_files/utils/viewing_modes.py
+++ b/count_files/utils/viewing_modes.py
@@ -155,7 +155,7 @@ def show_result_for_search_files(files: Iterable[str],
 
         print(f"   Total combined size: {h_total_size}.")
         print(f"   Average file size: {avg_size} (max: {h_max}, min: {h_min}).",
-                 end="\n\n")
+              end="\n\n")
     else:
         print("")
     return files_amount
@@ -181,3 +181,37 @@ def show_result_for_total(files: Iterable[str], no_feedback: bool) -> int:
     else:
         print(f'   Found {files_amount} file(s).', end="\n\n")
     return files_amount
+
+
+def show_help_columns(column_version: List[str], list_version: List[str],
+                      num_columns: int = 2, term_width: int = TERM_WIDTH) -> str:
+    """Displays a table with the specified number of columns.
+
+    Suitable for a list with short words.
+    If the words are very long and/or there are many columns
+    (the width of the table is greater than the width of the terminal),
+    then the data is displayed in a list.
+    When used in the help extension, the list is displayed using the textwrap fill().
+    For a table, the width of each column is equal
+    to the width of the longest word in the list.
+
+    :param column_version: list with words
+    The first in the list may be the names of the columns.
+    Example: column_version = ['LONG', 'SHORT',
+                               'path', 'path',
+                               'all', 'a',
+                               'args-help', 'ah']
+    :param list_version: list with words
+    :param num_columns: number of columns
+    :param term_width: width of the terminal; also required for testing
+    :return:
+    """
+    max_word_width = max(map(len, column_version))
+    if (max_word_width * num_columns + 3 * num_columns) > term_width:
+        return ', '.join(list_version)
+    text_table = " "
+    for count, item in enumerate(column_version, 1):
+        text_table += item.ljust(max_word_width + 3)
+        if count % num_columns == 0 or count == len(column_version):
+            text_table += "\n "
+    return text_table

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -5,14 +5,13 @@ from tests.test_viewing_modes import TestViewingModes
 
 
 def suite():
-    """Run all tests except TestViewingModes.test_show_result_for_search_files.
+    """Run all tests except performance tests.
     :return:
     """
     test_suite = unittest.TestSuite()
     test_suite.addTest(unittest.makeSuite(TestArgumentParser))
     test_suite.addTest(unittest.makeSuite(TestSomeFunctions))
-    test_suite.addTest(TestViewingModes('test_show_2columns_usual'))
-    test_suite.addTest(TestViewingModes('test_show_2columns_long'))
+    test_suite.addTest(unittest.makeSuite(TestViewingModes))
     return test_suite
 
 

--- a/tests/test_viewing_modes.py
+++ b/tests/test_viewing_modes.py
@@ -6,7 +6,8 @@ from contextlib import redirect_stdout
 import filecmp
 from collections import Counter
 
-from count_files.utils.viewing_modes import show_2columns, show_result_for_search_files, show_start_message
+from count_files.utils.viewing_modes import show_2columns, show_result_for_search_files, \
+    show_start_message, show_help_columns
 from count_files.utils.file_handlers import search_files
 
 
@@ -152,6 +153,15 @@ class TestViewingModes(unittest.TestCase):
                                  'ignoring hidden files and directories, in /some/path')
         self.assertEqual(total, 'Recursively counting total number of files with (case-sensitive) extension .TXT, '
                                 'including hidden files and directories, in /some/path')
+
+    def test_show_help_columns(self):
+        arguments = ['12345', '12345', '12345', '12345']
+        list_result = show_help_columns(column_version=arguments, list_version=arguments,
+                                        num_columns=2, term_width=10)
+        table_result = show_help_columns(column_version=arguments, list_version=arguments,
+                                         num_columns=2, term_width=50)
+        self.assertEqual(list_result, '12345, 12345, 12345, 12345')
+        self.assertEqual(table_result, ' 12345   12345   \n 12345   12345   \n ')
 
 # from root directory:
 # run all tests in test_viewing_modes.py


### PR DESCRIPTION
- Added help tables
https://github.com/victordomingos/Count-files/pull/97#pullrequestreview-192289999
def show_help_columns(displays table or list of topics - args, sort words, group names in help system extension). Based on def simple_columns.
The result depends on the width of the terminal.
- Updated tests: test for def show_help_columns, full test suite for test_viewing_modes in test_runner.py