### PR TITLE
Find group: search in pahs, extensions, filenames(excluding extension). Contains, startswith, endswith.

### DIFF
--- a/count_files/__main__.py
+++ b/count_files/__main__.py
@@ -26,7 +26,8 @@ from typing import TypeVar, Union
 from pathlib import Path
 from textwrap import fill
 
-from count_files.utils.file_handlers import is_supported_filetype, get_pattern_substring_and_type, handle_groups
+from count_files.utils.file_handlers import is_supported_filetype, get_pattern_substring_and_type, \
+    get_find_group_values
 from count_files.utils.viewing_modes import show_2columns, show_start_message, \
     show_result_for_total, show_result_for_search_files
 from count_files.platforms import get_current_os
@@ -190,8 +191,9 @@ def main_flow(*args: [argparse_namespace_object, Union[bytes, str]]):
     # Parser find_group: search for any folder, file of extension name in path
     find_group_args = any([args.path_substring, args.filename_substring, args.extension_substring])
     if find_group_args:
-        kw = {'path': args.path_substring, 'filename': args.filename_substring, 'extension': args.extension_substring}
-        substring, where = handle_groups(kw)
+        where_and_substring = {'path': args.path_substring, 'filename': args.filename_substring,
+                               'extension': args.extension_substring}
+        substring, where = get_find_group_values(where_and_substring)
         pattern_type, substring = get_pattern_substring_and_type(substring)
         print(fill(show_start_message(value='..', group='find', contains=[substring, where, pattern_type], **common_args),
                    width=START_TEXT_WIDTH),

--- a/count_files/settings.py
+++ b/count_files/settings.py
@@ -64,14 +64,58 @@ def simple_columns(text_input, num_columns=4):
     return text_table
 
 
-SUPPORTED_TYPE_INFO_MESSAGE = f'\nThis is the list of currently supported file types for preview:\n\n' \
+SUPPORTED_TYPE_INFO_MESSAGE = '\nThis is the list of currently supported file types for preview:\n\n' \
                               f'{simple_columns(SUPPORTED_TYPES["text"], num_columns=4)}\n' \
-                              f'Previewing files without extension is not supported. ' \
-                              f'You can use the "--preview" argument together with the search ' \
-                              f'for all files regardless of the extension ("--file-extension .."). ' \
-                              f'In this case, the preview will only be displayed for files with a supported extension.\n\n'
+                              'Previewing files without extension is not supported.\n' \
+                              'You can use the "--preview" argument together with the search ' \
+                              'for all files regardless of the extension ("--file-extension ..").\n' \
+                              'In this case, the preview will only be displayed for files ' \
+                              'with a supported extension.\n\n'
 
-NOT_SUPPORTED_TYPE_MESSAGE = f'\nSorry, there is no preview available for this file type. ' \
-                             f'You may want to try again without preview. ' \
-                             f'This is the list of currently supported file types for preview:\n\n' \
+NOT_SUPPORTED_TYPE_MESSAGE = '\nSorry, there is no preview available for this file type.\n' \
+                             'You may want to try again without preview.\n' \
+                             'This is the list of currently supported file types for preview:\n\n' \
                              f'{simple_columns(SUPPORTED_TYPES["text"], num_columns=4)}\n'
+
+
+SUPPORTED_PATTERN_MESSAGE = '\nExamples of usage with substitute character "*" ' \
+                            'that means "any number of any characters".\n' \
+                            'Can be used with: ' \
+                            '--path-contains, --filename-contains, --extension-contains\n' \
+                            'Help: count-files --args-help find\n' \
+                            'Extension starts with substring:\n' \
+                            '    count-files --extension-contains substring*\n' \
+                            'Filename ends with substring:\n' \
+                            '    count-files --filename-contains *substring\n' \
+                            'Path contains substring:\n' \
+                            '    count-files --path-contains *substring*\n' \
+                            '    or simply\n' \
+                            '    count-files --path-contains substring\n' \
+                            'Search for "*" itself:\n' \
+                            '    count-files --path-contains * (starts with "*")\n' \
+                            '    count-files --path-contains ** (ends with "*")\n' \
+                            '    count-files --path-contains *** (contains one "*")\n' \
+                            'Search is case insensitive by default. ' \
+                            'You can use the --case-sensitive argument.\n' \
+                            'The substring to search for may contain ' \
+                            'some special characters inside (sub.str*ing).\n' \
+                            'In this case character simply means the character itself.\n' \
+                            'Some characters may have special meaning for the terminal. ' \
+                            'If the substring to search for contains them or spaces, ' \
+                            'you need to specify it in quotes.'
+
+WARNING = '\nPlease use only one of the following commands:\n' \
+          'Total number of files.\n' \
+          '    count-files --total EXTENSION <arguments>\n' \
+          '    Help: count-files --args-help total\n' \
+          'File counting by extension.\n' \
+          '    count-files <arguments>\n' \
+          '    Help: count-files --args-help count\n' \
+          'File searching by extension.\n' \
+          '    count-files --file-extension FILE_EXTENSION <arguments>\n' \
+          '    Help: count-files --args-help search\n' \
+          'Find substring in a path, file name or extension.\n' \
+          '    count-files --path-contains PATH_SUBSTRING <arguments>\n' \
+          '    count-files --filename-contains FILENAME_SUBSTRING <arguments>\n' \
+          '    count-files --extension-contains EXTENSION_SUBSTRING <arguments>\n' \
+          '    Help: count-files --args-help find\n' \

--- a/count_files/utils/file_handlers.py
+++ b/count_files/utils/file_handlers.py
@@ -120,10 +120,11 @@ def check_pattern_matching(file_name: str, file_path: str, pattern_type: str,
     return result
 
 
-def handle_groups(kwargs: dict):
-    """
+def get_find_group_values(kwargs: dict):
+    """Get substring and where values for find group
 
-    :param kwargs:
+    :param kwargs: {'path': args.path_substring,
+    'filename': args.filename_substring, 'extension': args.extension_substring}
     :return: substring - find_group args value,
     where - 'path', 'filename', 'extension'
     """

--- a/count_files/utils/file_handlers.py
+++ b/count_files/utils/file_handlers.py
@@ -2,6 +2,7 @@
 # encoding: utf-8
 import os
 from itertools import chain
+from typing import Tuple
 
 from count_files.settings import SUPPORTED_TYPES
 
@@ -36,3 +37,98 @@ def is_supported_filetype(extension: str) -> bool:
     :return: True if we have a preview procedure for the given file type, False otherwise.
     """
     return extension in list(chain.from_iterable(SUPPORTED_TYPES.values()))
+
+
+def get_pattern_substring_and_type(pattern: str) -> Tuple[str, str]:
+    """The function determines the type of search pattern
+    and the substring to search for in paths, file names or file extensions.
+
+    Available patterns: substring*, *substring, *substring* or substring
+    (startswith, endswith, contains).
+    * - substitute character (mask "any number of any characters")
+
+    :param pattern: find_group args value
+    :return: pattern_type (startswith, endswith, contains),
+    substring (search substring, cleared from substitute characters)
+    """
+    # search for "*" itself in path
+    # "*" - start, "**" - end, "***" or more - contains 1 or more "*"
+    if set(pattern) == {'*'}:
+        if len(pattern) == 1:
+            pattern_type = 'startswith'
+            substring = '*'
+        elif len(pattern) == 2:
+            pattern_type = 'endswith'
+            substring = '*'
+        else:
+            pattern_type = 'contains'
+            substring = pattern[1: -1]
+        return pattern_type, substring
+
+    if pattern.startswith('*') and pattern.endswith('*'):
+        pattern_type = 'contains'
+        substring = pattern[1: -1]
+    elif pattern.startswith('*'):
+        pattern_type = 'endswith'
+        substring = pattern[1:]
+    elif pattern.endswith('*'):
+        pattern_type = 'startswith'
+        substring = pattern[:-1]
+    else:  # if "*" is not specified, search as is
+        pattern_type = 'contains'
+        substring = pattern
+    return pattern_type, substring
+
+
+def check_pattern_matching(file_name: str, file_path: str, pattern_type: str,
+                           substring: str, case_sensitive: bool, where: str) -> bool:
+    """Filter path, filename or file extension by search pattern.
+
+    Available patterns: substring*, *substring, *substring* (startswith, endswith, contains).
+    * - substitute character (mask "any number of any characters")
+    :param file_name: file name
+    :param file_path: full/path/to/file
+    :param pattern_type: startswith, endswith or contains
+    :param substring: find_group args value
+    :param case_sensitive: False -> ignore case in extensions,
+    True -> distinguish case variations in extensions
+    :param where: where to search by pattern
+    If where == 'path':
+    whole path if 'contains': search substring in folders, filename, extension
+    else: path starts with substring or path ends with substring
+    :return: True if path, filename or extension matches the search pattern, otherwise False
+    """
+    if where == 'extension':
+        # return extension as is
+        data = get_file_extension(file_name, case_sensitive=True)
+        if data == '.':
+            return False
+    elif where == 'filename':
+        data = os.path.splitext(file_name)[0]  # excluding extension
+    else:  # where == 'path':
+        data = file_path
+
+    data = data if case_sensitive else data.lower()
+    substring = substring if case_sensitive else substring.lower()
+
+    if pattern_type == 'startswith':
+        result = data.startswith(substring)
+    elif pattern_type == 'endswith':
+        result = data.endswith(substring)
+    else:  # pattern_type == 'contains':
+        result = substring in data
+    return result
+
+
+def handle_groups(kwargs: dict):
+    """
+
+    :param kwargs:
+    :return: substring - find_group args value,
+    where - 'path', 'filename', 'extension'
+    """
+    for k, v in kwargs.items():
+        if kwargs.get(k):
+            where = k
+            substring = kwargs[k]
+            return substring, where

--- a/count_files/utils/help_text.py
+++ b/count_files/utils/help_text.py
@@ -20,7 +20,9 @@ Partial argument name if it consists of two words.
 
 Sorting arguments by purpose:
 Service arguments: display of help, version of the program etc.
-(h or help, ah or args-help, v or version, st or supported-types)
+(h or help, ah or args-help,
+v or version, st or supported-types,
+sp or search-patterns)
 All service arguments.
     count-files --args-help service
 Get by name.
@@ -36,7 +38,9 @@ Get by name.
 Special arguments: arguments for counting or searching files.
 Count by extension: alpha or sort-alpha;
 Total number of files: t or total;
-Search by extension: fe or file-extension, fs or file-sizes, p or preview, ps or preview-size.
+Search by extension: fe or file-extension, fs or file-sizes, p or preview, ps or preview-size;
+Find substring in file paths: pc or path-contains, fc or filename-contains, ec or extension-contains
+(also file-sizes, preview and preview-size are used with this group).
 All special arguments.
     count-files --args-help special
 Get by name.
@@ -50,9 +54,10 @@ Sorting arguments by group, including group description:
     count-files --args-help count
     count-files --args-help search
     count-files --args-help total
+    count-files --args-help find
 
 Get group description:
-(count-group or cg, search-group or sg, total-group or tg)
+(count-group or cg, search-group or sg, total-group or tg, find-group or fg)
     count-files --args-help count-group
     count-files --args-help tg
 
@@ -95,7 +100,7 @@ Search by short/long argument name:
     count-files --args-help st
     count-files --args-help supported-types
 Sorting arguments by group, including group description:
-(count, search or total)
+(count, search, total or find)
     count-files --args-help count
 
 ADDITIONAL SECTIONS:
@@ -122,8 +127,11 @@ arguments = [
              'path', 'path',
              # optional
              'all', 'a', 'args-help', 'ah',
-             'case-sensitive', 'c', 'file-extension', 'fe', 'file-sizes', 'fs',
+             'case-sensitive', 'c', 'extension-contains', 'ec',
+             'file-extension', 'fe', 'file-sizes', 'fs',
+             'filename-contains', 'fc',
              'help', 'h', 'no-feedback', 'nf', 'no-recursion', 'nr',
+             'path-contains', 'pc',
              'preview', 'p', 'preview-size', 'ps',
              'sort-alpha', 'alpha', 'supported-types', 'st', 'total', 't', 'version', 'v']
 
@@ -158,7 +166,8 @@ AVAILABLE SORT WORDS:
 
 SORTING ARGUMENTS BY PURPOSE:
 Service arguments: display of help, version of the program etc.
-(h or help, ah or args-help, v or version, st or supported-types)
+(h or help, ah or args-help, v or version,
+st or supported-types, sp or search-patterns)
     count-files --args-help service
 Common arguments: directory path and sorting settings that are common to search and count.
 (path, a or all, c or case-sensitive, nr or no-recursion, nf or no-feedback)
@@ -166,7 +175,9 @@ Common arguments: directory path and sorting settings that are common to search 
 Special arguments: arguments for counting or searching files.
 Count by extension: alpha or sort-alpha;
 Total number of files: t or total;
-Search by extension: fe or file-extension, fs or file-sizes, p or preview, ps or preview-size.
+Search by extension: fe or file-extension, fs or file-sizes, p or preview, ps or preview-size;
+Find substring in file paths: pc or path-contains, fc or filename-contains, ec or extension-contains
+(also file-sizes, preview and preview-size are used with this group).
     count-files --args-help special
 
 SORTING ARGUMENTS BY TYPE:
@@ -181,6 +192,7 @@ group_names = [
     'cg, count-group', 'count',
     'sg, search-group', 'search',
     'tg, total-group', 'total',
+    'fg, find-group', 'find',
     # all group descriptions
     'group'
 ]
@@ -196,8 +208,10 @@ Sorting arguments by group, including group description.
     count-files --args-help count
     count-files --args-help search
     count-files --args-help total
+    count-files --args-help find
 Get group description.
-(count-group or cg, search-group or sg, total-group or tg)
+(count-group or cg, search-group or sg,
+total-group or tg, find-group or fg)
     count-files --args-help count-group
     count-files --args-help tg
 Get all group descriptions.
@@ -244,9 +258,9 @@ topics = {
     },
     'args-help': {
         'name': '-ah TOPIC, --args-help TOPIC',
-        'short': 'Search in help by topic - argument or group name(count, search, total). '
+        'short': 'Search in help by topic - argument or group name(count, search, total, find). '
                  'Show more detailed help text: count-files -ah docs.',
-        'long': 'Search in help by topic - argument or group name(count, search, total). '
+        'long': 'Search in help by topic - argument or group name(count, search, total, find). '
                  'Show more detailed help text: count-files -ah docs. '
                  'Show list of available topics: count-files -ah list. '
                  'Usage: count-files -ah <topic>.'
@@ -262,6 +276,15 @@ topics = {
         'short': 'The list of currently supported file types for preview.',
         'long': 'Show a list of currently supported file types for preview and exit. '
                 'Usage: count-files -st or count-files --supported-types.'
+    },
+    'find-patterns': {
+        'name': '-fp, --find-patterns',
+        'short': 'Show examples of currently supported patterns for searching '
+                 'for a substring in a path, file name or extension.',
+        'long': 'Show examples of currently supported patterns for searching '
+                'for a substring in a path, file name or extension. '
+                'Search with substitute character "*" that means "any number of any characters". '
+                'Usage: count-files -fp or count-files --find-patterns.'
     },
     'path': {
         'name': 'path',
@@ -322,21 +345,24 @@ topics = {
                 'you can use the -t or --total argument and specify the name of the extension. '
                 'Usage: count-files [-a, --all] [-c, --case-sensitive] '
                 '[-nr, --no-recursion] [-nf, --no-feedback] '
-                '[-t EXTENSION, --total EXTENSION] [path].'
+                '[-t EXTENSION, --total EXTENSION] [path]. '
+                'EXTENSION: exact name of the extension, '
+                '"."(files without an extension), ".."(all the files).'
     },
     'total': {
         'name': '-t EXTENSION, --total EXTENSION',
         'short': 'Get the total number of files with given extension in the directory. '
-                 'As the extension name: use a single dot "." for files without an extension '
-                 'or two dots ".." for all the files, regardless of the extension.',
+                 'EXTENSION: exact name of the extension, '
+                 '"."(files without an extension), ".."(all the files).',
         'long': 'Get the total number of files in the directory. '
                 'If you only need the total number of all files, '
                 'or the number of files with a certain extension or without it. '
-                'To count the total number of files, you must specify the name of the extension. '
-                'Example: count-files --total txt ~/Documents <arguments>. '
+                'EXTENSION: exact name of the extension, '
+                '"."(files without an extension), ".."(all the files).'
+                'Example with exact name: count-files --total txt ~/Documents <arguments>. '
                 'Use a single dot "." to get the total number of files that do not have an extension. '
                 'Example: count-files --total . ~/Documents <arguments>. '
-                'Use two dots without spaces ".." to get the total number of files, with or without a file extension. '
+                'Use two dots without spaces ".." to get the total number of all files. '
                 'Example: count-files --total .. ~/Documents <arguments>. '
     },
     'count-group': {
@@ -366,7 +392,7 @@ topics = {
         'name': 'File searching by extension',
         'short': 'Searching for files that have a given extension. '
                  'By default, it presents a simple list with full file paths. '
-                 'Optionally, it may also display a short text preview for each found file.',
+                 'Optionally, it may also display a short text preview and size for each found file.',
         'long': 'Searching for files that have a given extension. '
                 'This utility can be used to search for files that have a certain file extension '
                 '(using -fe or --file-extension) and, optionally, '
@@ -380,15 +406,20 @@ topics = {
                 'use the -fs or --file-sizes argument. '
                 'Usage: count-files [-a, --all] [-c, --case-sensitive] '
                 '[-nr, --no-recursion] [-fe FILE_EXTENSION, --file-extension FILE_EXTENSION] '
-                '[-fs, --file-sizes] [-p, --preview] [-ps PREVIEW_SIZE, --preview-size PREVIEW_SIZE] [path].'
+                '[-fs, --file-sizes] [-p, --preview] '
+                '[-ps PREVIEW_SIZE, --preview-size PREVIEW_SIZE] [path]. '
+                'FILE_EXTENSION: exact name of the extension, '
+                '"."(files without an extension), ".."(all the files).'
     },
     'file-extension': {
         'name': '-fe FILE_EXTENSION, --file-extension FILE_EXTENSION',
         'short': 'Searching and listing files by given extension in the directory. '
-                 'As the extension name: use a single dot "." for files without an extension '
-                 'or two dots ".." for all the files, regardless of the extension.',
+                 'FILE_EXTENSION: exact name of the extension, '
+                 '"."(files without an extension), ".."(all the files).',
         'long': 'Searching and listing files by extension. Specify the extension name. '
-                'Example: count-files --file-extension txt ~/Documents <arguments>. '
+                'FILE_EXTENSION: exact name of the extension, '
+                '"."(files without an extension), ".."(all the files). '
+                'Example with exact name: count-files --file-extension txt ~/Documents <arguments>. '
                 'Use a single dot "." to search for files without any extension. '
                 'Files with names such as .gitignore, Procfile, _netrc '
                 'are considered to have no extension in their name. '
@@ -430,6 +461,95 @@ topics = {
                 'found file when using -fe or --file_extension. '
                 'Additional information: total combined size and average file size. '
                 'Example: count-files --file-extension txt --file-sizes ~/Documents <arguments>.'
+    },
+    'find-group': {
+        'name': 'Find substring in a path, file name(excluding extension) or extension',
+        'short': 'Displays the location of the files matching the search pattern. '
+                 'Also --preview, --preview-size, --file-sizes arguments are available for this group. '
+                 'All arguments in the group are used separately from each other. '
+                 'Details: count-files --args-help find',
+        'long': 'Find substring in a path, file name(excluding extension) or extension. '
+                'Displays the location of the files matching the search pattern, '
+                'full paths of the files found. '
+                'All arguments in the group are used separately from each other. '
+                'Available search patterns: substring*, *substring, *substring* or simply substring '
+                '(startswith, endswith or contains substring). '
+                'Examples: count-files --path-contains tests <arguments>; '
+                'count-files --filename-contains urls <arguments>; '
+                'count-files --extension-contains j <arguments>. '
+                'Examples of usage with substitute character "*" '
+                'that means "any number of any characters": '
+                'count-files --path-contains *.css.gz* <arguments>; '
+                'count-files --filename-contains test_* <arguments>; '
+                'count-files --extension-contains *at <arguments>. '
+                'Search for "*" itself: count-files --path-contains * (starts with "*"); '
+                'count-files --path-contains ** (ends with "*"); '
+                'count-files --path-contains *** (contains one "*"). '
+                'Search for substring is case insensitive by default. '
+                'You can use the --case-sensitive argument. '
+                'Also --preview, --preview-size, --file-sizes arguments are available for this group. '
+                'Usage: count-files [-a, --all] [-c, --case-sensitive] '
+                '[-nr, --no-recursion] [-fs, --file-sizes] '
+                '[-p, --preview] [-ps PREVIEW_SIZE, --preview-size PREVIEW_SIZE] '
+                '[-pc PATH_SUBSTRING, --path-contains PATH_SUBSTRING] '
+                '[-fc FILENAME_SUBSTRING, --filename-contains FILENAME_SUBSTRING] '
+                '[-ec EXTENSION_SUBSTRING, --extension-contains EXTENSION_SUBSTRING] '
+                '[path]. '
+                'SUBSTRING: any character or word to check if the file path contains it. '
+                'The substring to search for may contain some special characters inside (sub.str*ing). '
+                'In this case character simply means the character itself. '
+                'Some characters may have special meaning for the terminal. '
+                'If the substring to search for contains them or spaces, you need to specify it in quotes.'
+    },
+    'path-contains': {
+        'name': '-pc PATH_SUBSTRING, --path-contains PATH_SUBSTRING',
+        'short': 'Find substring in paths. For example, any folder or filename. '
+                 'Details: count-files -ah pc',
+        'long': 'Displays the location of the files matching the search pattern. '
+                'Example: count-files --path-contains tests <arguments> '
+                'returns paths with subdirectory or file name that contain substring "tests". '
+                'Example of usage with substitute character "*" '
+                'that means "any number of any characters": '
+                'count-files --path-contains k* <arguments> returns any path that starts with "k". '
+                'Available search patterns: substring*, *substring, *substring* or simply substring '
+                '(startswith, endswith or contains substring). '
+                'Search for substring is case insensitive by default. '
+                'You can use the --case-sensitive argument. '
+                'PATH_SUBSTRING: any character or word to check if the path contains it.'
+    },
+    'filename-contains': {
+        'name': '-fc FILENAME_SUBSTRING, --filename-contains FILENAME_SUBSTRING',
+        'short': 'Find substring in file names(excluding extension). For example, full or partial file name. '
+                 'Details: count-files -ah fc',
+        'long': 'Displays the location of the files matching the search pattern. '
+                'For example, full or partial file name(excluding extension). '
+                'Example: count-files --filename-contains 2019_03 <arguments> '
+                'returns 2019_03_14, file_2019_03, 2019_03. '
+                'Example of usage with substitute character "*" '
+                'that means "any number of any characters": '
+                'count-files --filename-contains *settings <arguments> returns '
+                'any filename that ends with "settings" - local_settings, settings. '
+                'Available search patterns: substring*, *substring, *substring* or simply substring '
+                '(startswith, endswith or contains substring). '
+                'Search for substring is case insensitive by default. '
+                'You can use the --case-sensitive argument. '
+                'FILENAME_SUBSTRING: any character or word to check if the filename contains it.'
+    },
+    'extension-contains': {
+        'name': '-ec EXTENSION_SUBSTRING, --extension-contains EXTENSION_SUBSTRING',
+        'short': 'Find substring in extensions. For example, partial extension name. '
+                 'Details: count-files -ah ec',
+        'long': 'Displays the location of the files matching the search pattern. '
+                'Example: count-files --extension-contains htm <arguments> returns .html, .htm, .xhtml. '
+                'Example of usage with substitute character "*" '
+                'that means "any number of any characters": '
+                'count-files --extension-contains py* <arguments> returns '
+                'any extension that starts with "py" - .py, .pyc. '
+                'Available search patterns: substring*, *substring, *substring* or simply substring '
+                '(startswith, endswith or contains substring). '
+                'Search for substring is case insensitive by default. '
+                'You can use the --case-sensitive argument. '
+                'EXTENSION_SUBSTRING: any character or word to check if the extension contains it.'
     }
 }
 
@@ -444,7 +564,8 @@ indexes = {
         [topics['version']['name'], topics['version']['short'], topics['version']['long']],
     ('st', 'supported-types', 'supported', 'types', 'service', 'optional'):
         [topics['supported-types']['name'], topics['supported-types']['short'], topics['supported-types']['long']],
-
+    ('fp', 'find-patterns', 'find', 'patterns', 'service', 'optional'):
+        [topics['find-patterns']['name'], topics['find-patterns']['short'], topics['find-patterns']['long']],
     ('path', 'common', 'positional'):
         [topics['path']['name'], topics['path']['short'], topics['path']['long']],
     ('a', 'all', 'common', 'optional'):
@@ -475,7 +596,18 @@ indexes = {
     ('ps', 'preview-size', 'preview', 'size', 'search', 'special', 'optional'):
         [topics['preview-size']['name'], topics['preview-size']['short'], topics['preview-size']['long']],
     ('fs', 'file-sizes', 'file', 'sizes', 'search', 'special', 'optional'):
-        [topics['file-sizes']['name'], topics['file-sizes']['short'], topics['file-sizes']['long']]
+        [topics['file-sizes']['name'], topics['file-sizes']['short'], topics['file-sizes']['long']],
+
+    ('find-group', 'group', 'find', 'fg'):
+        [topics['find-group']['name'], topics['find-group']['short'], topics['find-group']['long']],
+    ('pc', 'path-contains', 'path', 'contains', 'find', 'special', 'optional'):
+        [topics['path-contains']['name'], topics['path-contains']['short'], topics['path-contains']['long']],
+    ('fc', 'filename-contains', 'filename', 'contains', 'find', 'special', 'optional'):
+        [topics['filename-contains']['name'],
+         topics['filename-contains']['short'], topics['filename-contains']['long']],
+    ('ec', 'extension-contains', 'extension', 'contains', 'find', 'special', 'optional'):
+        [topics['extension-contains']['name'],
+         topics['extension-contains']['short'], topics['extension-contains']['long']],
 }
 
 

--- a/count_files/utils/help_text.py
+++ b/count_files/utils/help_text.py
@@ -466,12 +466,14 @@ topics = {
         'name': 'Find substring in a path, file name(excluding extension) or extension',
         'short': 'Displays the location of the files matching the search pattern. '
                  'Also --preview, --preview-size, --file-sizes arguments are available for this group. '
-                 'All arguments in the group are used separately from each other. '
+                 'Arguments --path-contains, --filename-contains and --extension-contains '
+                 'are used separately from each other. '
                  'Details: count-files --args-help find',
         'long': 'Find substring in a path, file name(excluding extension) or extension. '
                 'Displays the location of the files matching the search pattern, '
                 'full paths of the files found. '
-                'All arguments in the group are used separately from each other. '
+                'Arguments --path-contains, --filename-contains and --extension-contains '
+                'are used separately from each other. '
                 'Available search patterns: substring*, *substring, *substring* or simply substring '
                 '(startswith, endswith or contains substring). '
                 'Examples: count-files --path-contains tests <arguments>; '

--- a/count_files/utils/help_text.py
+++ b/count_files/utils/help_text.py
@@ -22,7 +22,7 @@ Sorting arguments by purpose:
 Service arguments: display of help, version of the program etc.
 (h or help, ah or args-help,
 v or version, st or supported-types,
-sp or search-patterns)
+fp or find-patterns)
 All service arguments.
     count-files --args-help service
 Get by name.
@@ -167,7 +167,7 @@ AVAILABLE SORT WORDS:
 SORTING ARGUMENTS BY PURPOSE:
 Service arguments: display of help, version of the program etc.
 (h or help, ah or args-help, v or version,
-st or supported-types, sp or search-patterns)
+st or supported-types, fp or find-patterns)
     count-files --args-help service
 Common arguments: directory path and sorting settings that are common to search and count.
 (path, a or all, c or case-sensitive, nr or no-recursion, nf or no-feedback)

--- a/count_files/utils/viewing_modes.py
+++ b/count_files/utils/viewing_modes.py
@@ -47,15 +47,16 @@ def human_mem_size(num: int, suffix: str = 'B') -> str:
 
 
 def show_start_message(value: [None, str], case_sensitive: bool, recursive: bool, include_hidden: bool,
-                       location: str, group: str = None) -> str:
+                       dirpath: str, group: str = None, contains: List[str] = None) -> str:
     """Displays a message with information about selected counting or searching CLI arguments.
 
     :param value: str for args.total or args.file_extension, for table - None.
     :param case_sensitive: args.case_sensitive
     :param recursive: args.no_recursion
     :param include_hidden: args.all
-    :param location: path argument
-    :param group: for now 'total' or None
+    :param dirpath: path argument
+    :param group: 'total', 'find' or None
+    :param contains: contains=[substring, where, pattern_type]
     :return: prints information message
     """
     wi = 'or without it'
@@ -69,6 +70,18 @@ def show_start_message(value: [None, str], case_sensitive: bool, recursive: bool
         nr = 'Counting total number of files'
         e = f' with{" (" + case + ")" if value not in [".", ".."] else ""} ' \
             f'extension {"." + value if value != ".." else wi}'
+    # search for any folder or file name in path
+    elif group == 'find':
+        if 'with' in contains[2]:
+            pt = contains[2].split('w')[0] + " with"
+        else:
+            pt = contains[2].split('s')[0]
+        r = f'Recursively searching for {contains[1]}s that {pt} the substring "{contains[0]}"'
+        nr = f'Searching for {contains[1]}s that {pt} the substring "{contains[0]}"'
+        c = f'{"(" + case + ")" if {case} else ""}'
+        message = f'{r if recursive else nr} {c},' \
+                  f'{h if include_hidden else nh}, in {dirpath}'
+        return message
     # count_group and search_group
     else:
         action = 'searching' if value else 'counting'
@@ -78,7 +91,7 @@ def show_start_message(value: [None, str], case_sensitive: bool, recursive: bool
             f'extension {"." + value if value != ".." else wi}' if value else ''
 
     message = f'{r if recursive else nr}{e if value != "." else all_e},' \
-              f'{h if include_hidden else nh}, in {location}'
+              f'{h if include_hidden else nh}, in {dirpath}'
 
     return message
 

--- a/tests/test_argument_parser.py
+++ b/tests/test_argument_parser.py
@@ -12,6 +12,27 @@ class TestArgumentParser(unittest.TestCase):
     def get_locations(self, *args):
         return os.path.normpath(os.path.join(os.path.dirname(__file__), *args))
 
+    # searching by pattern with include_hidden=True(suitable for all operation systems), found group
+    def test_path_contains_argument(self):
+        self.assertEqual(main_flow([self.get_locations(), '-pc', 'os_file', '-a']), 1)
+        self.assertEqual(main_flow([self.get_locations(), '-pc', '2columns', '-a']), 8)
+        self.assertEqual(main_flow([self.get_locations(), '-pc', 'cprofile_test.py', '-a']), 1)
+        # little faster than -fe, but less accurate
+        self.assertEqual(main_flow([self.get_locations('data_for_tests'), '-pc', '.TXT', '-c', '-a']), 1)
+
+    def test_extension_contains_argument(self):
+        self.assertEqual(main_flow([self.get_locations('data_for_tests'), '-ec', '*j*', '-a']), 1)
+        self.assertEqual(main_flow([self.get_locations('data_for_tests'), '-ec', '*X*', '-a', '-c']), 1)
+        self.assertEqual(main_flow([self.get_locations('data_for_tests'), '-ec', 'm*', '-a']), 2)
+        self.assertEqual(main_flow([self.get_locations('data_for_tests'), '-ec', '*tml', '-a']), 1)
+
+    def test_filename_contains_argument(self):
+        self.assertEqual(main_flow([self.get_locations('data_for_tests'), '-fc', '*no_extension*', '-a']), 1)
+        self.assertEqual(main_flow([self.get_locations('data_for_tests'), '-fc', '*_ext', '-a']), 1)
+        self.assertEqual(main_flow([self.get_locations('data_for_tests'), '-fc', '*_EXT', '-a', '-c']), 0)
+        self.assertEqual(main_flow([self.get_locations('data_for_tests'), '-fc', 'ext_*', '-a']), 2)
+        self.assertEqual(main_flow([self.get_locations('data_for_tests'), '-fc', 'html_file', '-a']), 1)
+
     # counting total number of files
     def test_countfiles_all_t(self):
         """Testing def main_flow.

--- a/tests/test_file_handlers.py
+++ b/tests/test_file_handlers.py
@@ -1,0 +1,65 @@
+import unittest
+import os
+
+from count_files.utils.file_handlers import get_file_extension, get_pattern_substring_and_type, \
+    check_pattern_matching
+
+
+class TestFileHandlers(unittest.TestCase):
+
+    def get_locations(self, *args):
+        return os.path.normpath(os.path.join(os.path.dirname(__file__), *args))
+
+    def test_get_file_extension(self):
+        """Testing def get_file_extension.
+
+        Extract only the file extension from a given path.
+        Expected behavior: return extension name (txt, py) or '.' (for files without extension)
+        :return:
+        """
+        extensions_dict = {'file.py': 'py', '.gitignore': '.', 'image.JPG': 'JPG',
+                           'file': '.', '.hidden_file.txt': 'txt',
+                           '.hidden.file.txt': 'txt', 'select2.3805311d5fc1.css.gz': 'gz'
+                           }
+        for k, v in extensions_dict.items():
+            with self.subTest(k=k, v=v):
+                self.assertEqual(get_file_extension(k, case_sensitive=True), v)
+
+    def test_get_pattern_substring_and_type(self):
+        ext_dict = {'substring*': ('startswith', 'substring'), '*substring': ('endswith', 'substring'),
+                    '*substring*': ('contains', 'substring'), 'substring': ('contains', 'substring'),
+                    '*': ('startswith', '*'), '**': ('endswith', '*'),
+                    '***': ('contains', '*'), '****': ('contains', '**'),
+                    'sub?str.ing': ('contains', 'sub?str.ing'), '**substring': ('endswith', '*substring'),
+                    'substring***': ('startswith', 'substring**'), '**substring*': ('contains', '*substring')}
+        for k, v in ext_dict.items():
+            with self.subTest(k=k, v=v):
+                self.assertEqual(get_pattern_substring_and_type(k), v)
+
+    def test_check_pattern_matching(self):
+        """
+        param extension_pattern cleared in def get_extension_pattern_and_type
+        :return:
+        """
+        # file_name, file_path,
+        # pattern_type, substring, case, where, result
+        test_list = [('py_file_for_tests.py', self.get_locations('data_for_tests', 'py_file_for_tests.py'),
+                      'contains', 'for', False, 'filename', True),
+                     ('py_file_for_tests.py', self.get_locations('data_for_tests', 'py_file_for_tests.py'),
+                      'contains', 'django', False, 'path', False),
+                     ('py_file_for_tests.py', self.get_locations('data_for_tests', 'py_file_for_tests.py'),
+                     'startswith', 'py', False, 'extension', True),
+                     ('ext_in_uppercase.TXT', self.get_locations('data_for_tests', 'ext_in_uppercase.TXT'),
+                     'endswith', 'T', True, 'extension', True),
+                     # default False for [no_extension]
+                     ('no_extension', self.get_locations('data_for_tests', 'no_extension'),
+                      'contains', 'n', False, 'extension', False),
+                     ]
+        for i in test_list:
+            with self.subTest(i=i):
+                self.assertEqual(check_pattern_matching(file_name=i[0], file_path=i[1], pattern_type=i[2],
+                                                        substring=i[3], case_sensitive=i[4], where=i[5]), i[6])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_find_with_patterns.py
+++ b/tests/test_find_with_patterns.py
@@ -1,0 +1,91 @@
+import unittest
+import os
+
+from count_files.platforms import get_current_os
+
+
+class TestFindPatterns(unittest.TestCase):
+
+    def setUp(self):
+        self.current_os = get_current_os()
+
+    def get_locations(self, *args):
+        return os.path.normpath(os.path.join(os.path.dirname(__file__), *args))
+
+    def test_find_group_pc(self):
+        # get all matches count-files -pc substring
+        # contains ['substring', 'where', 'type']
+        result = self.current_os.search_files(self.get_locations('data_for_tests'),
+                                              '..', contains=['django', 'path', 'contains'],
+                                              recursive=True, include_hidden=True, case_sensitive=False)
+        result1 = self.current_os.search_files(self.get_locations('data_for_tests'),
+                                               '..', contains=['ext', 'path', 'contains'],
+                                               recursive=True, include_hidden=True, case_sensitive=False)
+        result2 = self.current_os.search_files(self.get_locations('data_for_tests'),
+                                               '..', contains=['webfont', 'path', 'contains'],
+                                               recursive=True, include_hidden=True, case_sensitive=False)
+        result3 = self.current_os.search_files(self.get_locations('data_for_tests'),
+                                               '..', contains=['SELECT2', 'path', 'contains'],
+                                               recursive=True, include_hidden=True, case_sensitive=True)
+        self.assertEqual(len(list(result)), 10)
+        self.assertEqual(len(list(result1)), 4)
+        self.assertEqual(len(list(result2)), 1)
+        self.assertEqual(len(list(result3)), 2)
+
+    def test_find_group_pc2(self):
+        # get all matches count-files -pc substring
+        result = self.current_os.search_files(self.get_locations('data_for_tests'),
+                                              '..', contains=[f'css{os.sep}vendor', 'path', 'contains'],
+                                              recursive=True, include_hidden=True, case_sensitive=False)
+        result1 = self.current_os.search_files(self.get_locations('data_for_tests'),
+                                               '..', contains=['staticfiles.json', 'path', 'contains'],
+                                               recursive=True, include_hidden=True, case_sensitive=False)
+        result2 = self.current_os.search_files(self.get_locations('data_for_tests'),
+                                               '..', contains=['.txt.gz', 'path', 'contains'],
+                                               recursive=True, include_hidden=True, case_sensitive=False)
+        self.assertEqual(len(list(result)), 4)
+        self.assertEqual(len(list(result1)), 1)
+        self.assertEqual(len(list(result2)), 1)
+
+    def test_find_group_ec(self):
+        result = self.current_os.search_files(self.get_locations('data_for_tests'),
+                                              '..', contains=['htm', 'extension', 'startswith'],
+                                              recursive=True, include_hidden=True, case_sensitive=False)
+        result1 = self.current_os.search_files(self.get_locations('data_for_tests'),
+                                               '..', contains=['on', 'extension', 'endswith'],
+                                               recursive=True, include_hidden=True, case_sensitive=False)
+        result2 = self.current_os.search_files(self.get_locations('data_for_tests'),
+                                               '..', contains=['md', 'extension', 'contains'],
+                                               recursive=True, include_hidden=True, case_sensitive=False)
+        result3 = self.current_os.search_files(self.get_locations('data_for_tests'),
+                                               '..', contains=['T', 'extension', 'contains'],
+                                               recursive=True, include_hidden=True, case_sensitive=True)
+        self.assertEqual(len(list(result)), 1)
+        self.assertEqual(len(list(result1)), 1)
+        self.assertEqual(len(list(result2)), 2)
+        self.assertEqual(len(list(result3)), 1)
+
+    def test_find_group_fc(self):
+        result = self.current_os.search_files(self.get_locations('data_for_tests'),
+                                              '..', contains=['html', 'filename', 'startswith'],
+                                              recursive=True, include_hidden=True, case_sensitive=False)
+        result1 = self.current_os.search_files(self.get_locations('data_for_tests'),
+                                               '..', contains=['on', 'filename', 'endswith'],
+                                               recursive=True, include_hidden=True, case_sensitive=False)
+        result2 = self.current_os.search_files(self.get_locations('data_for_tests'),
+                                               '..', contains=['ext', 'filename', 'contains'],
+                                               recursive=True, include_hidden=True, case_sensitive=False)
+        result3 = self.current_os.search_files(self.get_locations('data_for_tests'),
+                                               '..', contains=['LICENSE', 'filename', 'contains'],
+                                               recursive=True, include_hidden=True, case_sensitive=True)
+        self.assertEqual(len(list(result)), 1)
+        self.assertEqual(len(list(result1)), 1)
+        self.assertEqual(len(list(result2)), 4)
+        self.assertEqual(len(list(result3)), 4)
+
+# python -m unittest tests.test_find_with_patterns.TestFindPatterns
+# python -m unittest tests.test_find_with_patterns.TestFindPatterns.test_find_group_fc
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2,6 +2,8 @@ import unittest
 from tests.test_argument_parser import TestArgumentParser
 from tests.test_some_functions import TestSomeFunctions
 from tests.test_viewing_modes import TestViewingModes
+from tests.test_file_handlers import TestFileHandlers
+from tests.test_find_with_patterns import TestFindPatterns
 
 
 def suite():
@@ -12,6 +14,8 @@ def suite():
     test_suite.addTest(unittest.makeSuite(TestArgumentParser))
     test_suite.addTest(unittest.makeSuite(TestSomeFunctions))
     test_suite.addTest(unittest.makeSuite(TestViewingModes))
+    test_suite.addTest(unittest.makeSuite(TestFileHandlers))
+    test_suite.addTest(unittest.makeSuite(TestFindPatterns))
     return test_suite
 
 

--- a/tests/test_some_functions.py
+++ b/tests/test_some_functions.py
@@ -4,7 +4,6 @@ import os
 import sys
 from collections import Counter
 
-from count_files.utils.file_handlers import get_file_extension
 from count_files.platforms import get_current_os
 from count_files.utils.file_preview import generate_preview, generic_text_preview
 
@@ -16,21 +15,6 @@ class TestSomeFunctions(unittest.TestCase):
 
     def get_locations(self, *args):
         return os.path.normpath(os.path.join(os.path.dirname(__file__), *args))
-
-    def test_get_file_extension(self):
-        """Testing def get_file_extension.
-
-        Extract only the file extension from a given path.
-        Expected behavior: return extension name (txt, py) or '.' (for files without extension)
-        :return:
-        """
-        extensions_dict = {'file.py': 'py', '.gitignore': '.', 'image.JPG': 'JPG',
-                           'file': '.', '.hidden_file.txt': 'txt',
-                           '.hidden.file.txt': 'txt', 'select2.3805311d5fc1.css.gz': 'gz'
-                           }
-        for k, v in extensions_dict.items():
-            with self.subTest(k=k, v=v):
-                self.assertEqual(get_file_extension(k, case_sensitive=True), v)
 
     # test case_sensitive param (search, count, total)
     def test_search_files_case_sensitive(self):

--- a/tests/test_viewing_modes.py
+++ b/tests/test_viewing_modes.py
@@ -143,17 +143,25 @@ class TestViewingModes(unittest.TestCase):
         :return:
         """
         count = show_start_message(value=None, case_sensitive=False, recursive=True, include_hidden=False,
-                                   location='/some/path', group=None)
+                                   dirpath='/some/path', group=None)
         search = show_start_message(value='.', case_sensitive=False, recursive=False, include_hidden=False,
-                                    location='/some/path', group=None)
+                                    dirpath='/some/path', group=None)
         total = show_start_message(value='TXT', case_sensitive=True, recursive=True, include_hidden=True,
-                                   location='/some/path', group='total')
+                                   dirpath='/some/path', group='total')
+        find = show_start_message(value='..', case_sensitive=True, recursive=True, include_hidden=True,
+                                  dirpath='/some/path', group='find', contains=['abc', 'path', 'contains'])
+        find1 = show_start_message(value='..', case_sensitive=False, recursive=False, include_hidden=False,
+                                   dirpath='/some/path', group='find', contains=['def', 'filename', 'endswith'])
         self.assertEqual(count, 'Recursively counting all files, '
                                 'ignoring hidden files and directories, in /some/path')
         self.assertEqual(search, 'Searching files without any extension, '
                                  'ignoring hidden files and directories, in /some/path')
         self.assertEqual(total, 'Recursively counting total number of files with (case-sensitive) extension .TXT, '
                                 'including hidden files and directories, in /some/path')
+        self.assertEqual(find, 'Recursively searching for paths that contain the substring "abc" '
+                               '(case-sensitive), including hidden files and directories, in /some/path')
+        self.assertEqual(find1, 'Searching for filenames that ends with the substring "def" '
+                                '(case-insensitive), ignoring hidden files and directories, in /some/path')
 
     def test_show_help_columns(self):
         arguments = ['12345', '12345', '12345', '12345']


### PR DESCRIPTION
Find group: displays the location of the files matching the search pattern (list).
`--path-contains`
`--filename-contains`
`--extension-contains`
Arguments `--path-contains`, `--filename-contains` and `--extension-contains` 
are used separately from each other.
Also `--preview`, `--preview-size`, `--file-sizes` arguments are available for this group.
Service argument:
`--find-patterns` - short info about usage
Available patterns: `substring*`, `*substring`, `*substring*` or `substring`
 (startswith, endswith, contains).
`*` - substitute character (mask "any number of any characters")
substring: any character or word to check if the path, filename, extnsion contains it.

Also:
- updated tests
- updated print info and start messages in main.py
- updated passing args to functions in main.py
- added check for incompatible args
- added new messages in settings

