### PR TITLE
Preview files: added new parser.exit() tests, several new extensions

### DIFF
--- a/count_files/settings.py
+++ b/count_files/settings.py
@@ -51,7 +51,7 @@ if device in ("iPad", "iPhone"):
 SUPPORTED_TYPES = {
     'all_extensions': ['..'],
     'no_extension': ['.'],
-    'text_expected': text_extensions_and_mime_types.keys()
+    'text': text_extensions_and_mime_types.keys()
 }
 
 
@@ -66,7 +66,7 @@ def simple_columns(text_input, num_columns=4):
 
 
 SUPPORTED_TYPE_INFO_MESSAGE = f'\nThis is the list of currently supported file types for preview:\n\n' \
-                              f'{simple_columns(SUPPORTED_TYPES["text_expected"], num_columns=4)}\n' \
+                              f'{simple_columns(SUPPORTED_TYPES["text"], num_columns=4)}\n' \
                               f'Previewing files without extension is not supported. ' \
                               f'You can use the "--preview" argument together with the search ' \
                               f'for all files regardless of the extension ("--file-extension .."). ' \

--- a/count_files/utils/file_handlers.py
+++ b/count_files/utils/file_handlers.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # encoding: utf-8
 import os
+from itertools import chain
 
 from count_files.settings import SUPPORTED_TYPES
 
@@ -34,4 +35,4 @@ def is_supported_filetype(extension: str) -> bool:
     :param extension: extension name (txt, py), '.'(without extension) or '..' (all extensions)
     :return: True if we have a preview procedure for the given file type, False otherwise.
     """
-    return extension in SUPPORTED_TYPES['text_expected']
+    return extension in list(chain.from_iterable(SUPPORTED_TYPES.values()))

--- a/count_files/utils/file_preview.py
+++ b/count_files/utils/file_preview.py
@@ -54,7 +54,7 @@ def generate_preview(filepath: str, max_size: int = 390) -> str:
     """
     extension = get_file_extension(filepath, case_sensitive=False).lower()
 
-    if extension in SUPPORTED_TYPES['text_expected']:
+    if extension in SUPPORTED_TYPES['text']:
         excerpt = generic_text_preview(filepath, max_size)
         if excerpt:
             # return excerpt or error string

--- a/count_files/utils/text_extensions.py
+++ b/count_files/utils/text_extensions.py
@@ -11,9 +11,12 @@ and not registered types
 text_extensions_and_mime_types = {
     'py': '',  # Python Script, application/x-python-code, text/x-python, text/plain
     'pyw': '',  # Windows Python GUI Source File
+    'pyt': '',  # Python Toolbox, text/plain
+    'rpy': '',  # Python Script, Ren'Py Script - text/plain, may be Touhou Project Replay File
     'php': '',  # PHP, application/x-httpd-php, text/php, application/php, magnus-internal/shellcgi, application/x-php
     'bat': '',  # DOS Batch File, text/plain
     'cmd': '',  # Windows Command File, Files similar in functionality to BAT file format, text/plain
+    'sh': '',  # Bash Shell Script - text/plain, or Unix Shell Archive(Compressed Files, .shar)
     'vbs': '',  # VBScript File
     'cs': '',  # C# Source Code File
     'erl': '',  # Erlang Source Code File
@@ -33,6 +36,7 @@ text_extensions_and_mime_types = {
     'yaml': '',  # YAML Document application/x-yaml
     'latex': '',  # LaTeX Document
     'ltx': '',  # LaTeX Document
+    'cfg': '',  # Configuration/Settings Files, may be saved in a text format, Windows and Macintosh systems
     'qss': '',  # Qt Style Sheet
 
     # http://svn.apache.org/viewvc/httpd/httpd/trunk/docs/conf/mime.types?view=markup
@@ -53,7 +57,7 @@ text_extensions_and_mime_types = {
     'n3': 'text/n3',
     'txt': 'text/plain',
     'text': 'text/plain',
-    'conf': 'text/plain',
+    'conf': 'text/plain',  # Configuration/Settings Files, may be saved in a text format, Unix and Linux based systems
     'def': 'text/plain',
     'list': 'text/plain',
     'log': 'text/plain',
@@ -109,30 +113,32 @@ text_extensions_and_mime_types = {
     'uu': 'text/x-uuencode',
     'vcs': 'text/x-vcalendar',
     'vcf': 'text/x-vcard',
-}  # 95
+}  # 99
 
 """
-Python Software Foundation:
+Python related extensions:
 py   Python Script, python.exe
-pyc  Python Compiled File
+pyc  Python Compiled File, Python byte code
 pyw  Windows Python GUI Source File, pythonw.exe
-pyo  Python Optimized Code
+pyo  Python Optimized Code, Compiled Python File, Python byte code
 pyz  Python Archive File, application/x-zip-compressed
 pyzw Python Archive File, application/x-zip-compressed
-pyt  Python declaration data
-npy	 Python NumPy Array File	
-pyd	 Python Dynamic Module
-rpy  Python Script
+pyt  Python declaration data, Python Toolbox
+npy  Python NumPy Array File
+pyd  Python Dynamic Module, an equivalent of DLL format (dynamic link library), Binary
+rpy  Python Script, Ren'Py Script
 whl  Python Wheel Package, Compressed Files
 oog  related to Object Oriented Graphics (OOG) in PyGraph -  Python Graphics Interface
 p4a  Python script, optimized for Google Android system and apps
 pil  Python Image Library font
-pth  Python path configuration
+pth  Python path configuration, also: common PyTorch convention is to save models using either a .pt or .pth file
 pym  Python preprocessor macro
-ssdf Simple Structured Data Format, scientific data Python or Matlab
-pickle Python Pickle data
-egg
-egg-info
+ssdf  Simple Structured Data Format, scientific data Python or Matlab
+pickle  Python Pickle data, application/octet-stream, also *.pck, *.pcl, *.pkl(in Python 2)
+ipy  IPython script
+ipynb  IPython notebook, Jupyter Notebook
+egg  Python egg metadata, regenerated from source files by setuptools
+egg-info  Python egg metadata, regenerated from source files by setuptools
 """
 
 """

--- a/tests/test_argument_parser.py
+++ b/tests/test_argument_parser.py
@@ -18,7 +18,9 @@ class TestArgumentParser(unittest.TestCase):
 
         Recursive/non recursive counting.
         Testing for hidden files is not carried out here.
+        There are no hidden files or folders in data_for_tests.
         Equivalent to "count-files ~/.../tests/data_for_tests -a -t .."
+        Passed: path exists and not hidden.
         :return:
         """
         self.assertEqual(main_flow([self.get_locations('data_for_tests'), '-t', '..']), 16)
@@ -34,11 +36,13 @@ class TestArgumentParser(unittest.TestCase):
         Non recursive counting.
         Equivalent to
         "count-files ~/.../tests/data_for_tests/django_staticfiles_for_test -nr -fe {extension}"
+        There are no hidden files or folders in data_for_tests.
+        Passed: path exists and not hidden.
         :return:
         """
         location = self.get_locations('data_for_tests')
-        extensions = {'py': 2, 'json': 1, 'woff': 1, '.': 2, 'TXT': 3, 'txt': 3}
-        nr_extensions = {'css': 0, '.': 1, 'TXT': 1, 'txt': 1}
+        extensions = {'py': 2, 'json': 1, 'woff': 1, '.': 2, 'TXT': 3, 'txt': 3, '..': 16}
+        nr_extensions = {'css': 0, '.': 1, 'TXT': 1, 'txt': 1, '..': 6}
         # case-insensitive and recursive
         for k, v in extensions.items():
             with self.subTest(k=k, v=v):
@@ -47,6 +51,20 @@ class TestArgumentParser(unittest.TestCase):
         for k, v in nr_extensions.items():
             with self.subTest(k=k, v=v):
                 self.assertEqual(main_flow([location, '-nr', '-c', '-fe', f'{k}']), v)
+
+    def test_countfiles_fe_and_preview(self):
+        """Testing def main_flow.
+
+        Passed: --preview for supported types.
+        Not a visual presentation(other tests), but the fact that there is no SystemExit.
+        :return:
+        """
+        location = self.get_locations('data_for_tests')
+        extensions = {'json': 1, 'TXT': 3, '..': 16}
+        # case-insensitive and recursive + preview
+        for k, v in extensions.items():
+            with self.subTest(k=k, v=v):
+                self.assertEqual(main_flow([location, '-fe', f'{k}', '-p', '-ps', '5']), v)
 
     # tests for hidden files, Linux and Mac OS
     @unittest.skipIf(sys.platform.startswith("win"), "not for Windows")
@@ -73,6 +91,99 @@ class TestArgumentParser(unittest.TestCase):
         """
         self.assertEqual(main_flow([self.get_locations('test_hidden_windows'), '-nr', '-t', '..']), 1)
         self.assertEqual(main_flow([self.get_locations('test_hidden_windows'), '-nr', '-t', '..', '-a']), 2)
+
+    # SystemExit, parser.exit tests, Negative cases
+    def test_parser_exit(self):
+        """Check if all checks are performed in CLI.
+
+        1-2-3)The path does not exist, or there may be a typo in it.
+        4)Preview for an unsupported file type(no extension).
+        5)Preview for an unsupported file type(not in SUPPORTED_TYPES).
+        :return:
+        """
+        args_dict = {(self.get_locations('not_exists'),): 1,
+                     (self.get_locations('not_exists'), '-t', 'txt'): 1,
+                     (self.get_locations('not_exists'), '-fe', '..'): 1,
+                     # -fe used, no preview to count and -t
+                     (self.get_locations('data_for_tests'), '-fe', '.', '-p'): 1,
+                     (self.get_locations('data_for_tests'), '-fe', 'woff', '-p'): 1}
+        for k, v in args_dict.items():
+            with self.subTest(k=k, v=v):
+                try:
+                    main_flow(k)
+                # should return parser.exit(status=1)
+                except SystemExit as se:
+                    # main_flow return parser.exit(status=0) for count_group if check is not effected in CLI
+                    self.assertEqual(se.code, v)
+                except Exception as e:
+                    self.fail(f'Unexpected exception raised: {e}')
+                else:
+                    # main_flow return total_result for --total if check is not effected in CLI
+                    # main_flow return len(files) for -fe .. if check is not effected in CLI
+                    self.fail('SystemExit not raised')
+
+    @unittest.skipUnless(sys.platform.startswith('win'), 'for Windows')
+    def test_parser_exit_for_hidden_win(self):
+        """Check if all checks are performed in CLI.
+
+        If include_hidden=False and hidden folder in path:
+        In this case, the hidden folder is skipped(default settings)
+        and, accordingly, the files are not count at all.
+        TODO: revise the check for cases when:
+        count-files ~/Documents/not_hidden_subfolder/hidden_folder
+        You can count files in Documents, not_hidden_subfolder and not count them in a hidden_folder.
+        :return:
+        """
+        # if not include_hidden and current_os.is_hidden_file_or_dir(location)
+        args_dict = {(self.get_locations('test_hidden_windows', 'folder_hidden_for_win'),): 1,
+                     (self.get_locations('test_hidden_windows', 'folder_hidden_for_win'), '-t', 'txt'): 1,
+                     (self.get_locations('test_hidden_windows', 'folder_hidden_for_win'), '-fe', '..'): 1}
+        for k, v in args_dict.items():
+            with self.subTest(k=k, v=v):
+                try:
+                    main_flow(k)
+                # should return parser.exit(status=1)
+                except SystemExit as se:
+                    # main_flow return parser.exit(status=0) for count_group if check is not effected in CLI
+                    self.assertEqual(se.code, v)
+                except Exception as e:
+                    self.fail(f'Unexpected exception raised: {e}')
+                else:
+                    # main_flow return total_result for --total if check is not effected in CLI
+                    # main_flow return len(files) for -fe .. if check is not effected in CLI
+                    self.fail('SystemExit not raised')
+
+    @unittest.skipIf(sys.platform.startswith("win"), "not for Windows")
+    def test_parser_exit_for_hidden_unix(self):
+        """Check if all checks are performed in CLI.
+
+        If include_hidden=False and hidden folder in path:
+        In this case, the hidden folder is skipped(default settings)
+        and, accordingly, the files are not count at all.
+        TODO: revise the check for cases when:
+        count-files ~/Documents/not_hidden_subfolder/hidden_folder
+        You can count files in Documents, not_hidden_subfolder and not count them in a hidden_folder.
+        :return:
+        """
+        # if not include_hidden and current_os.is_hidden_file_or_dir(location)
+        args_dict = {(self.get_locations('test_hidden_linux', '.ebookreader'),): 1,
+                     (self.get_locations('test_hidden_linux', '.ebookreader'), '-t', 'txt'): 1,
+                     (self.get_locations('test_hidden_linux', '.ebookreader'), '-fe', '..'): 1}
+        for k, v in args_dict.items():
+            with self.subTest(k=k, v=v):
+                try:
+                    main_flow(k)
+                # should return parser.exit(status=1)
+                except SystemExit as se:
+                    # main_flow return parser.exit(status=0) for count_group if check is not effected in CLI
+                    self.assertEqual(se.code, v)
+                except Exception as e:
+                    self.fail(f'Unexpected exception raised: {e}')
+                else:
+                    # main_flow return total_result for --total if check is not effected in CLI
+                    # main_flow return len(files) for -fe .. if check is not effected in CLI
+                    self.fail('SystemExit not raised')
+
 
 # from root directory:
 


### PR DESCRIPTION
- added new parser.exit() tests
ArgumentParser tests: path not exists, hidden path entered, --preview for not supported extensions
- several new extensions
Python related: pyt, rpy. Common: sh, cfg
- rewrited SUPPORTED_TYPES['text'], it was possible not to change