### PR TITLE
New args for total group: show folders and total size.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ tests/compare_tables/test_show_result_list.txt
 tests/compare_tables/win_show_result_list.txt
 tests/compare_tables/darwin_show_result_list.txt
 tests/compare_tables/linux_show_result_list.txt
+tests/compare_tables/test_show_result_total.txt
+tests/compare_tables/win_show_result_total.txt
+tests/compare_tables/darwin_show_result_total.txt
+tests/compare_tables/linux_show_result_total.txt
 
 ### PyCharm ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm

--- a/count_files/__main__.py
+++ b/count_files/__main__.py
@@ -81,6 +81,12 @@ total_group = parser.add_argument_group('Total number of files'.upper(),
 total_group.add_argument('-t', '--total', dest="extension", type=str,
                          help=topics['total']['short'])
 
+total_group.add_argument('-sf', '--show-folders', action='store_true', default=False,
+                         help=topics['show-folders']['short'])
+
+total_group.add_argument('-ts', '--total-size', action='store_true', default=False,
+                         help=topics['total-size']['short'])
+
 
 count_group = parser.add_argument_group('File counting by extension'.upper(),
                                         description=topics['count-group']['short'])
@@ -176,7 +182,10 @@ def main_flow(*args: [argparse_namespace_object, Union[bytes, str]]):
                                        include_hidden=include_hidden,
                                        recursive=recursive,
                                        case_sensitive=args.case_sensitive)
-        total_result = show_result_for_total(data, args.no_feedback)
+        total_result = show_result_for_total(data, total_size=args.total_size,
+                                             show_folders=args.show_folders,
+                                             no_feedback=args.no_feedback,
+                                             recursive=recursive)
         return total_result
 
     # Parser search_group

--- a/count_files/utils/help_text.py
+++ b/count_files/utils/help_text.py
@@ -55,8 +55,8 @@ arguments = [
              'file-extension', 'fe', 'file-sizes', 'fs',
              'help', 'h', 'help-cmd', 'hc',
              'no-feedback', 'nf', 'no-recursion', 'nr',
-             'preview', 'p', 'preview-size', 'ps',
-             'sort-alpha', 'alpha', 'supported-types', 'st', 'total', 't', 'version', 'v']
+             'preview', 'p', 'preview-size', 'ps', 'show-folders', 'sf',
+             'sort-alpha', 'alpha', 'supported-types', 'st', 'total', 't', 'total-size', 'ts', 'version', 'v']
 
 docs_args_text = f"""COUNT FILES HELP(ARGS).
 
@@ -255,7 +255,8 @@ topics = {
                 'you can use the -t or --total argument and specify the name of the extension. '
                 'Usage: count-files [-a, --all] [-c, --case-sensitive] '
                 '[-nr, --no-recursion] [-nf, --no-feedback] '
-                '[-t EXTENSION, --total EXTENSION] [path].'
+                '[-t EXTENSION, --total EXTENSION] [-sf, --show-folders] '
+                '[-ts, --total-size] [path].'
     },
     'total': {
         'name': '-t EXTENSION, --total EXTENSION',
@@ -271,6 +272,24 @@ topics = {
                 'Example: count-files --total . ~/Documents <arguments>. '
                 'Use two dots without spaces ".." to get the total number of files, with or without a file extension. '
                 'Example: count-files --total .. ~/Documents <arguments>. '
+    },
+    'show-folders': {
+        'name': '-sf, --show-folders',
+        'short': 'Show the list of folders in which the found files are located, '
+                 'and the number of found files in each folder.',
+        'long': 'Show the list of folders in which the found files are located. '
+                'In addition, the number of found files in each folder is displayed. '
+                'When recursively counting all files(--total ..) and using the --show-folders argument, '
+                'all folders containing files are displayed. '
+                'To include hidden folders, also add the --all argument. '
+                'Example: count-files --total py --show-folders ~/Documents <arguments>.'
+    },
+    'total-size': {
+        'name': '-ts, --total-size',
+        'short': 'Show the total combined size of files found using the -t or --total argument.',
+        'long': 'Show the total combined size of files found using the -t or --total argument. '
+                'Additional information: average, minimum and maximum file size. '
+                'Example: count-files --total txt --total-size ~/Documents <arguments>.'
     },
     'count-group': {
         'name': 'File counting by extension',
@@ -393,6 +412,10 @@ indexes = {
         [topics['total-group']['name'], topics['total-group']['short'], topics['total-group']['long']],
     ('t', 'total', 'extension', 'special', 'optional'):
         [topics['total']['name'], topics['total']['short'], topics['total']['long']],
+    ('sf', 'show-folders', 'show', 'folders', 'total', 'special', 'optional'):
+        [topics['show-folders']['name'], topics['show-folders']['short'], topics['show-folders']['long']],
+    ('ts', 'total-size', 'total', 'size', 'special', 'optional'):
+        [topics['total-size']['name'], topics['total-size']['short'], topics['total-size']['long']],
 
     ('count-group', 'group', 'count', 'cg'):
         [topics['count-group']['name'], topics['count-group']['short'], topics['count-group']['long']],

--- a/tests/performance_tests/timeit_test.py
+++ b/tests/performance_tests/timeit_test.py
@@ -49,8 +49,9 @@ show_2columns(data, max_word_width, total_occurrences)
 
 total_and_extension = """
 data = current_os.search_files(dirpath=location, extension='..',
-recursive=True, include_hidden=True, case_sensitive=False)
-len_files = show_result_for_total(files=data, no_feedback=False)
+recursive=True, include_hidden=False, case_sensitive=False)
+len_files = show_result_for_total(files=data, show_folders=True, 
+total_size=True, no_feedback=False, recursive=True)
 """
 
 


### PR DESCRIPTION
- added new optional args, show_folders and total_size in main.py
- updated def show_result_for_total with new args:
Additionally: prints a list of folders in which the found files are located, the number of found files in each folder and the total combined size of the found files (if specified). When recursively counting all files(--total ..) and using the --show-folders argument, all folders containing files are displayed.
- help text.py: added new args descriptions
- added test related to def show_result_for_total in test_viewing_modes.py, generates test files and compares the output using new arguments.

TODO: update documentation, README and examples
