### PR TITLE
Search by pattern, search for file names(including extension) with fnmatch module, support for Unix shell-style wildcards

### DIFF
--- a/count_files/settings.py
+++ b/count_files/settings.py
@@ -69,7 +69,8 @@ SUPPORTED_TYPE_INFO_MESSAGE = f'\nThis is the list of currently supported file t
                               f'{simple_columns(SUPPORTED_TYPES["text"], num_columns=4)}\n' \
                               f'Previewing files without extension is not supported. ' \
                               f'You can use the "--preview" argument together with the search ' \
-                              f'for all files regardless of the extension ("--file-extension .."). ' \
+                              f'for all files regardless of the extension ("--file-extension ..") ' \
+                              f'or with the search by pattern ("--filename-match"). ' \
                               f'In this case, the preview will only be displayed for files ' \
                               f'with a supported extension.\n\n'
 

--- a/count_files/utils/help_text.py
+++ b/count_files/utils/help_text.py
@@ -52,7 +52,7 @@ arguments = [
              'path', 'path',
              # optional
              'all', 'a', 'case-sensitive', 'c',
-             'file-extension', 'fe', 'file-sizes', 'fs',
+             'file-extension', 'fe', 'filename-match', 'fm', 'file-sizes', 'fs',
              'help', 'h', 'help-cmd', 'hc',
              'no-feedback', 'nf', 'no-recursion', 'nr',
              'preview', 'p', 'preview-size', 'ps', 'show-folders', 'sf',
@@ -100,8 +100,8 @@ Common arguments: directory path and sorting settings that are common to search 
     help> common
 Special arguments: arguments for counting or searching files.
 Count by extension: alpha or sort-alpha;
-Total number of files: t or total;
-Search by extension: fe or file-extension, fs or file-sizes, p or preview, ps or preview-size.
+Total number of files: t or total, sf or show-folders, ts or total-size;
+Search by extension: fe or file-extension, fm or filename-match, fs or file-sizes, p or preview, ps or preview-size.
     help> special
 
 SORTING ARGUMENTS BY TYPE:
@@ -315,23 +315,29 @@ topics = {
                 'Example: count-files ---sort-alpha ~/Documents <arguments>.'
     },
     'search-group': {
-        'name': 'File searching by extension',
-        'short': 'Searching for files that have a given extension. '
-                 'By default, it presents a simple list with full file paths. '
-                 'Optionally, it may also display a short text preview for each found file.',
-        'long': 'Searching for files that have a given extension. '
+        'name': 'File searching by extension or by pattern',
+        'short': 'Search for files with a given extension or files matching a specific pattern. '
+                 'By default, it presents a simple list with full file paths.',
+        'long': 'Searching for files that have a given extension or files matching a specific pattern. '
                 'This utility can be used to search for files that have a certain file extension '
-                '(using -fe or --file-extension) and, optionally, '
-                'display a short preview (-p or --preview) for text files. '
+                '(using -fe or --file-extension). '
+                'You can also search for files using Unix shell-style wildcards: *, ?, [seq], [!seq] '
+                '(-fm or --filename-match argument). '
+                '* - matches everything (zero or more occurrences of any character), '
+                '? - matches any single character, '
+                '[seq] - matches any character in seq, [!seq] - matches any character not in seq. '
+                'For a literal match, wrap the meta-characters in brackets. '
+                'For example, "[?]" matches the character "?". '
+                'Optionally, you can get a short preview for text files(-p or --preview). '
                 'The size of the preview text sample can be customized '
                 'by using the -ps or --preview-size argument '
                 'followed by an integer number specifying the number of characters to present. '
-                'By default, the result of a search by a certain file extension '
-                'is a list of the full paths of the files found. '
+                'By default, the result of a search is a list of the full paths of the files found. '
                 'If you need information about the size of the files, '
                 'use the -fs or --file-sizes argument. '
                 'Usage: count-files [-a, --all] [-c, --case-sensitive] '
                 '[-nr, --no-recursion] [-fe FILE_EXTENSION, --file-extension FILE_EXTENSION] '
+                '[-fm PATTERN, --filename-match PATTERN] '
                 '[-fs, --file-sizes] [-p, --preview] [-ps PREVIEW_SIZE, --preview-size PREVIEW_SIZE] [path].'
     },
     'file-extension': {
@@ -349,13 +355,29 @@ topics = {
                 'with or without file extensions in their names. '
                 'Example: count-files --file-extension .. ~/Documents <arguments>. '
     },
+    'filename-match': {
+        'name': '-fm PATTERN, --filename-match PATTERN',
+        'short': 'Searching and listing files matching a specific pattern, '
+                 'using Unix shell-style wildcards: *, ?, [seq], [!seq].',
+        'long': 'Searching and listing files matching a specific pattern, '
+                'using Unix shell-style wildcards: *, ?, [seq], [!seq]. '
+                '* - matches everything (zero or more occurrences of any character), '
+                '? - matches any single character, '
+                '[seq] - matches any character in seq, [!seq] - matches any character not in seq. '
+                'For a literal match, wrap the meta-characters in brackets. '
+                'For example, "[?]" matches the character "?". '
+                'Example for .pyc, .pyo and similar files: '
+                'count-files --filename-match *.py? ~/Documents <arguments>. '
+                'Example for file names containing the word "test": '
+                'count-files --filename-match *test* ~/Documents <arguments>.'
+    },
     'preview': {
         'name': '-p, --preview',
         'short': 'Display a short preview (only available for text files when '
-                 'using -fe or --file_extension).',
+                 'using --file-extension or --filename-match arguments).',
         'long': 'Display a short preview (only for text files). '
                 'Preview is available as an option when searching files '
-                'using the -fe or --file-extension argument. '
+                'using --file-extension or --filename-match arguments. '
                 'The default text preview size depends on the terminal width settings. '
                 'You can change this value by specifying the argument -ps or --preview-size. '
                 'Example: count-files --file-extension txt --preview ~/Documents <arguments>.'
@@ -366,7 +388,7 @@ topics = {
                  'when using -p or --preview.',
         'long': 'Specify the number of characters to be displayed from each found file. '
                 'Preview text files is available as an option when searching files '
-                'using the --file-extension and --preview argument. '
+                'using the --file-extension or --filename-match arguments with --preview argument. '
                 f'Default preview size: {DEFAULT_PREVIEW_SIZE} characters (5 lines). '
                 'The default text preview size depends on the terminal width settings. '
                 'You can change this value by specifying the argument -ps or --preview-size '
@@ -377,9 +399,9 @@ topics = {
     'file-sizes': {
         'name': '-fs, --file-sizes',
         'short': 'Show size info for each '
-                 'found file when using -fe or --file_extension.',
+                 'found file when using --file-extension or --filename-match arguments.',
         'long': 'Show size info for each '
-                'found file when using -fe or --file_extension. '
+                'found file when using --file-extension or --filename-match arguments. '
                 'Additional information: total combined size and average file size. '
                 'Example: count-files --file-extension txt --file-sizes ~/Documents <arguments>.'
     }
@@ -426,6 +448,8 @@ indexes = {
         [topics['search-group']['name'], topics['search-group']['short'], topics['search-group']['long']],
     ('fe', 'file-extension', 'file', 'extension', 'search', 'special', 'optional'):
         [topics['file-extension']['name'], topics['file-extension']['short'], topics['file-extension']['long']],
+    ('fm', 'filename-match', 'filename', 'match', 'pattern', 'search', 'special', 'optional'):
+        [topics['filename-match']['name'], topics['filename-match']['short'], topics['filename-match']['long']],
     ('p', 'preview', 'search', 'special', 'optional'):
         [topics['preview']['name'], topics['preview']['short'], topics['preview']['long']],
     ('ps', 'preview-size', 'preview', 'size', 'search', 'special', 'optional'):

--- a/count_files/utils/viewing_modes.py
+++ b/count_files/utils/viewing_modes.py
@@ -50,12 +50,12 @@ def show_start_message(value: [None, str], case_sensitive: bool, recursive: bool
                        location: str, group: str = None) -> str:
     """Displays a message with information about selected counting or searching CLI arguments.
 
-    :param value: str for args.total or args.file_extension, for table - None.
+    :param value: for args.pattern, args.total or args.file_extension - string, for table - None.
     :param case_sensitive: args.case_sensitive
     :param recursive: args.no_recursion
     :param include_hidden: args.all
     :param location: path argument
-    :param group: for now 'total' or None
+    :param group: 'pattern'(search_group -fm), 'total' or None(count_group and search_group -fe)
     :return: prints information message
     """
     wi = 'or without it'
@@ -64,22 +64,28 @@ def show_start_message(value: [None, str], case_sensitive: bool, recursive: bool
     h = ' including hidden files and directories'
     nh = ' ignoring hidden files and directories'
 
-    if group == 'total':
-        r = f'Recursively counting total number of files'
-        nr = 'Counting total number of files'
-        e = f' with{" (" + case + ")" if value not in [".", ".."] else ""} ' \
-            f'extension {"." + value if value != ".." else wi}'
-    # count_group and search_group
+    if group == 'pattern':  # search_group --filename-match [pattern]
+        r = f'Recursively searching for files'
+        nr = f'Searching for files'
+        message = f'{r if recursive else nr} with{" (" + case + ") pattern"} {value},' \
+                  f'{h if include_hidden else nh}, in {location}'
+
     else:
-        action = 'searching' if value else 'counting'
-        r = f'Recursively {action} all files'
-        nr = f'{action.title()} files'
-        e = f' with{" (" + case + ")" if value not in [".", ".."] else ""} ' \
-            f'extension {"." + value if value != ".." else wi}' if value else ''
+        if group == 'total':
+            r = f'Recursively counting total number of files'
+            nr = 'Counting total number of files'
+            e = f' with{" (" + case + ")" if value not in [".", ".."] else ""} ' \
+                f'extension {"." + value if value != ".." else wi}'
+        else:
+            # count_group and search_group -fe
+            action = 'searching' if value else 'counting'
+            r = f'Recursively {action} all files'
+            nr = f'{action.title()} files'
+            e = f' with{" (" + case + ")" if value not in [".", ".."] else ""} ' \
+                f'extension {"." + value if value != ".." else wi}' if value else ''
 
-    message = f'{r if recursive else nr}{e if value != "." else all_e},' \
-              f'{h if include_hidden else nh}, in {location}'
-
+        message = f'{r if recursive else nr}{e if value != "." else all_e},' \
+                  f'{h if include_hidden else nh}, in {location}'
     return message
 
 

--- a/tests/test_some_functions.py
+++ b/tests/test_some_functions.py
@@ -249,6 +249,37 @@ class TestSomeFunctions(unittest.TestCase):
         self.assertEqual(result_nr, counter2)
         self.assertEqual(result_nr_hidden, counter3)
 
+    def test_search_files_by_pattern(self):
+        """Testing def search_files_by_pattern.
+
+        Search for file names matching given pattern(including extension).
+        https://docs.python.org/3/library/fnmatch.html
+        Unix shell-style wildcards: *, ?, [seq], [!seq]
+        * - matches everything, ? - matches any single character
+        [seq] - matches any character in seq, [!seq] - matches any character not in seq
+        For a literal match, wrap the meta-characters in brackets.
+        For example, '[?]' matches the character '?'.
+        Note that the filename separator ('/' on Unix) is not special to this module.
+        Similarly, filenames starting with a period are not special for this module,
+        and are matched by the * and ? patterns.
+        :return:
+        """
+        # extensions: html, json, woff
+        ext_result = list(current_os.search_files_by_pattern(dirpath=self.get_locations('data_for_tests'),
+                                                             pattern='*.????', recursive=True,
+                                                             include_hidden=False, case_sensitive=False))
+        # word in filename
+        word_result = list(current_os.search_files_by_pattern(dirpath=self.get_locations('data_for_tests'),
+                                                              pattern='*test*', recursive=True,
+                                                              include_hidden=False, case_sensitive=False))
+        # case-sensitive
+        case_result = list(current_os.search_files_by_pattern(dirpath=self.get_locations('data_for_tests'),
+                                                              pattern='LICENSE*', recursive=True,
+                                                              include_hidden=False, case_sensitive=True))
+        self.assertEqual(len(ext_result), 3)
+        self.assertEqual(len(word_result), 3)
+        self.assertEqual(len(case_result), 4)
+
 
 # from root directory:
 


### PR DESCRIPTION
Changes related to previous discussions.
 Search by other criteria:
https://github.com/victordomingos/Count-files/issues/88
Search by pattern also allows you to search for several similar extensions(partially):
https://github.com/victordomingos/Count-files/issues/92

- added def search_files_by_pattern
search for file names(including extension) using Unix shell-style wildcards: ` *`, `?`, `[seq]`, `[!seq]`;
used `fnmatch.fnmatch(filename, pattern)` and `fnmatch.fnmatchcase(filename, pattern)` from PSL https://docs.python.org/3/library/fnmatch.html;
result is a generator with full paths.

- added new argument `--filename-match PATTERN` as part of parser search group
if you use this argument, common args and special search group arguments are available (`preview`, `previw-size`, `file-sizes`);
except for the `--file-extension`  argument, which is used separately;
preview behavior is similar to --file-extension .. (all extensions),
in this case, the preview will only be displayed for files with a supported extension.

- updated help_text, start message for CLI, SUPPORTED_TYPE_INFO_MESSAGE
- added test

Examples:
`count-files --filename-match *test*` returns files with word test in filename
`count-files --filename-match setup.py` returns exact file
`count-files --filename-match *.py?` returns files with extensions `.pyc`, `.pyo`, `.pyd`, `.pyw` and so on
