### PR TITLE
Fnmatch. Filename and pattern in lower case, for pattern inputted in partial upper case (case-insensitive mode).

### DIFF
--- a/count_files/platforms.py
+++ b/count_files/platforms.py
@@ -155,7 +155,8 @@ class BaseOS(object):
                 f_path = os.path.join(root, f)
                 if not os.path.isfile(f_path):
                     continue
-                result = fnmatch.fnmatchcase(f, pattern) if case_sensitive else fnmatch.fnmatch(f, pattern)
+                result = fnmatch.fnmatchcase(f, pattern) if case_sensitive \
+                    else fnmatch.fnmatch(f.lower(), pattern.lower())
                 if result:
                     if include_hidden or not self.is_hidden_file_or_dir(f_path):
                         yield f_path

--- a/count_files/platforms.py
+++ b/count_files/platforms.py
@@ -150,13 +150,14 @@ class BaseOS(object):
         if True - distinguish case variations in extensions
         :return: object <class 'generator'> with full paths to all found files
         """
+        pattern = pattern if case_sensitive else pattern.lower()
         for root, dirs, files in os.walk(dirpath):
             for f in files:
                 f_path = os.path.join(root, f)
                 if not os.path.isfile(f_path):
                     continue
                 result = fnmatch.fnmatchcase(f, pattern) if case_sensitive \
-                    else fnmatch.fnmatch(f.lower(), pattern.lower())
+                    else fnmatch.fnmatch(f.lower(), pattern)
                 if result:
                     if include_hidden or not self.is_hidden_file_or_dir(f_path):
                         yield f_path

--- a/tests/test_some_functions.py
+++ b/tests/test_some_functions.py
@@ -276,9 +276,25 @@ class TestSomeFunctions(unittest.TestCase):
         case_result = list(current_os.search_files_by_pattern(dirpath=self.get_locations('data_for_tests'),
                                                               pattern='LICENSE*', recursive=True,
                                                               include_hidden=False, case_sensitive=True))
+        partial_case_result = list(current_os.search_files_by_pattern(dirpath=self.get_locations('data_for_tests'),
+                                                                      pattern='*.Md', recursive=True,
+                                                                      include_hidden=False, case_sensitive=True))
+        partial_case_result1 = list(current_os.search_files_by_pattern(dirpath=self.get_locations('data_for_tests'),
+                                                                       pattern='*.Md', recursive=True,
+                                                                       include_hidden=False, case_sensitive=False))
+        upper_case_result = list(current_os.search_files_by_pattern(dirpath=self.get_locations('data_for_tests'),
+                                                                    pattern='*.MD', recursive=True,
+                                                                    include_hidden=False, case_sensitive=False))
+        upper_case_result1 = list(current_os.search_files_by_pattern(dirpath=self.get_locations('data_for_tests'),
+                                                                     pattern='*.MD', recursive=True,
+                                                                     include_hidden=False, case_sensitive=True))
         self.assertEqual(len(ext_result), 3)
         self.assertEqual(len(word_result), 3)
         self.assertEqual(len(case_result), 4)
+        self.assertEqual(len(partial_case_result), 0)
+        self.assertEqual(len(partial_case_result1), 2)
+        self.assertEqual(len(upper_case_result), 2)
+        self.assertEqual(len(upper_case_result1), 0)
 
 
 # from root directory:


### PR DESCRIPTION
Fnmatch uses os.path.normcase(), whose behavior is platform dependent.
Lowercased filename and pattern should work correctly for all systems.
 It's my mess to clean up. It’s good that you noticed. I planned to test the program on other operating systems, for example on Ubuntu, later. But it’s not a fact that I would check such a possibility of entering a pattern. Good work. Thanks!