### PR TITLE
Group extensions by type: -g/--group argument in Count group. And updates to handle the extreme case when (term_width - freq_col_width - 5) becomes 0 or a negative value.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ tests/compare_tables/test_show_group_ext_and_freq.txt
 tests/compare_tables/show_group_ext_and_freq.txt
 tests/compare_tables/test_show_ext_grouped_by_type.txt
 tests/compare_tables/show_ext_grouped_by_type.txt
+tests/compare_tables/test_show_group_ext_and_freq_table.txt
+tests/compare_tables/show_group_ext_and_freq_table.txt
 
 ### PyCharm ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ tests/compare_tables/win_show_result_total.txt
 tests/compare_tables/darwin_show_result_total.txt
 tests/compare_tables/linux_show_result_total.txt
 tests/compare_tables/baseos_show_result_total.txt
+tests/compare_tables/test_show_group_ext_and_freq.txt
+tests/compare_tables/show_group_ext_and_freq.txt
+tests/compare_tables/test_show_ext_grouped_by_type.txt
+tests/compare_tables/show_ext_grouped_by_type.txt
 
 ### PyCharm ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm

--- a/count_files/__main__.py
+++ b/count_files/__main__.py
@@ -31,13 +31,14 @@ from textwrap import fill
 
 from count_files.utils.file_handlers import is_supported_filetype
 from count_files.utils.viewing_modes import show_2columns, show_start_message, \
-    show_result_for_total, show_result_for_search_files
+    show_result_for_total, show_result_for_search_files, show_ext_grouped_by_type, show_group_ext_and_freq
 from count_files.platforms import get_current_os
 from count_files.settings import SUPPORTED_TYPE_INFO_MESSAGE, NOT_SUPPORTED_TYPE_MESSAGE, \
-    DEFAULT_PREVIEW_SIZE, START_TEXT_WIDTH
+    DEFAULT_PREVIEW_SIZE, START_TEXT_WIDTH, TERM_WIDTH, DEFAULT_FREQ_COL_WIDTH
 from count_files.utils.help_system_extension import HelpCmd
 from count_files.utils.help_text import topics
 from count_files.utils.decorators import exceptions_decorator
+from count_files.utils.group_extensions import ext_and_group_dict
 
 
 parser = ArgumentParser(
@@ -96,6 +97,9 @@ count_group = parser.add_argument_group('File counting by extension'.upper(),
 
 count_group.add_argument('-alpha', '--sort-alpha', action='store_true', default=False,
                          help=topics['sort-alpha']['short'])
+
+count_group.add_argument('-g', '--group', action='store_true', default=False,
+                         help=topics['group']['short'])
 
 search_group = parser.add_argument_group('File searching by extension or by pattern'.upper(),
                                          description=topics['search-group']['short'])
@@ -258,16 +262,22 @@ def main_flow(*args: [argparse_namespace_object, Union[bytes, str]]):
         
     total_occurrences = sum(data.values())
     max_word_width = max(map(len, data.keys()))
-
-    if sort_alpha:
+    if args.group:
+        # sort extensions by group and by frequency in each group
+        show_ext_grouped_by_type(data=data.most_common(), ext_and_group=ext_and_group_dict)
+        print(f'\n  Found {total_occurrences} file(s).')
+        parser.exit(status=0)
+    elif sort_alpha:
         # sort extensions alphabetically, with uppercase versions on top
         sort_key = lambda data: (data[0].casefold(), data[0])
         data = sorted(data.items(), key=sort_key)
+        show_2columns(data, max_word_width, total_occurrences)
+        parser.exit(status=0)
     else:
         # sort extensions by frequency for each file extension
         data = data.most_common()
-    show_2columns(data, max_word_width, total_occurrences)
-    parser.exit(status=0)
+        show_2columns(data, max_word_width, total_occurrences)
+        parser.exit(status=0)
 
 
 if __name__ == "__main__":

--- a/count_files/__main__.py
+++ b/count_files/__main__.py
@@ -31,10 +31,10 @@ from textwrap import fill
 
 from count_files.utils.file_handlers import is_supported_filetype
 from count_files.utils.viewing_modes import show_2columns, show_start_message, \
-    show_result_for_total, show_result_for_search_files, show_ext_grouped_by_type, show_group_ext_and_freq
+    show_result_for_total, show_result_for_search_files, show_ext_grouped_by_type
 from count_files.platforms import get_current_os
 from count_files.settings import SUPPORTED_TYPE_INFO_MESSAGE, NOT_SUPPORTED_TYPE_MESSAGE, \
-    DEFAULT_PREVIEW_SIZE, START_TEXT_WIDTH, TERM_WIDTH, DEFAULT_FREQ_COL_WIDTH
+    DEFAULT_PREVIEW_SIZE, START_TEXT_WIDTH
 from count_files.utils.help_system_extension import HelpCmd
 from count_files.utils.help_text import topics
 from count_files.utils.decorators import exceptions_decorator

--- a/count_files/utils/file_handlers.py
+++ b/count_files/utils/file_handlers.py
@@ -2,6 +2,7 @@
 # encoding: utf-8
 import os
 from itertools import chain
+from typing import List, Tuple, Dict
 
 from count_files.settings import SUPPORTED_TYPES
 
@@ -36,3 +37,37 @@ def is_supported_filetype(extension: str) -> bool:
     :return: True if we have a preview procedure for the given file type, False otherwise.
     """
     return extension in list(chain.from_iterable(SUPPORTED_TYPES.values()))
+
+
+def group_ext_by_type(data: List[Tuple[str, int]],
+                      ext_and_group: Dict[str, str]) -> Dict[str, List[Tuple[str, int]]]:
+    """Group file extensions by type.
+
+    Default ext_and_group:
+    archives, audio, audio/video, data, documents, executables, fonts, images,
+    Python related extensions, videos, and other files.
+    User-defined ext_and_group:
+    may be created from configuration file.
+    Initial storage: dict with items like {'documents': [], 'images': [], ...}
+    key - group name, value - empty list.
+    'other': reserved key.
+    :param data: list with items like [('png', 8), ('txt', 25), ...]
+    :param ext_and_group: dict with items like {'png': 'image', 'txt': documents, ...}
+    :return: sorted dict with items like {'documents': [('txt', 25), ...], 'images': [('png', 8), ...], ...}
+    """
+    # storage: Dict[str, list]
+    # local scope important
+    storage = dict.fromkeys(sorted(set(ext_and_group.values())), [])
+    other = []
+    for (ext, freq) in data:
+        item_type = ext_and_group.get(ext.lower(), 'other')
+        if item_type == 'other':
+            other.append((ext, freq))
+        else:
+            if storage.get(item_type):
+                storage[item_type].append((ext, freq))
+            else:
+                storage[item_type] = [(ext, freq)]
+    if other:
+        storage.update({'other': other})
+    return storage

--- a/count_files/utils/group_extensions.py
+++ b/count_files/utils/group_extensions.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+ext_and_group_dict = {
+    '7z': 'archives',
+    'arc': 'archives',
+    'arj': 'archives',
+    'bz': 'archives',
+    'bz2': 'archives',
+    'bzip2': 'archives',
+    'cab': 'archives',
+    'dar': 'archives',
+    'gz': 'archives',
+    'gzip': 'archives',
+    'jar': 'archives',
+    'lz': 'archives',
+    'lzma': 'archives',
+    'rar': 'archives',
+    'shar': 'archives',
+    'shr': 'archives',
+    'tar': 'archives',
+    'tbz': 'archives',
+    'tbz2': 'archives',
+    'tg': 'archives',
+    'tgz': 'archives',
+    'txz': 'archives',
+    'xz': 'archives',
+    'zip': 'archives',
+    'zipx': 'archives',
+
+    # https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers
+    '3gp': 'audio/video',
+    '3gp2': 'audio/video',
+    '3gpp': 'audio/video',
+    '3gpp2': 'audio/video',
+    'mp4': 'audio/video',
+    'mpeg': 'audio/video',
+    'mpg': 'audio/video',
+    'ogg': 'audio/video',
+    'webm': 'audio/video',
+
+    'aac': 'audio',
+    'aif': 'audio',
+    'aiff': 'audio',
+    'amr': 'audio',
+    'cda': 'audio',
+    'flac': 'audio',
+    'mp1': 'audio',
+    'mp2': 'audio',
+    'mp3': 'audio',
+    'm4a': 'audio',
+    'mid': 'audio',
+    'midi': 'audio',
+    'mka': 'audio',
+    'mpa': 'audio',
+    'oga': 'audio',
+    'wav': 'audio',
+    'wave': 'audio',
+    'wma': 'audio',
+
+    'accdb': 'data',  # Microsoft Access databases
+    'accdc': 'data',  # Microsoft Access databases
+    'accde': 'data',  # Microsoft Access compiled execute only database
+    'csv': 'data',
+    'dat': 'data',  # data or resource files, may be anything
+    'data': 'data',  # data or resource files
+    'database': 'data',  # databases
+    'db': 'data',  # databases
+    'dbf': 'data',  # databases
+    'ini': 'data',  # configuration files
+    'cfg': 'data',  # configuration files
+    'conf': 'data',  # configuration files
+    'geojson': 'data',
+    'json': 'data',
+    'log': 'data',
+    'mdb': 'data',  # databases
+    'mysql': 'data',
+    'numbers': 'data',  # spreadsheet, Apple Numbers application on Mac OS X (macOS), iOS
+    'odb': 'data',  # OpenDocument databases, LibreOffice
+    'ods': 'data',  # OpenDocument spreadsheet, LibreOffice
+    'pdb': 'data',  # databases
+    'sqlite': 'data',  # databases
+    'sqlite3': 'data',  # databases
+    'sqlitedb': 'data',  # databases
+    'topojson': 'data',
+    'torrent': 'data',  # configuration files
+    'tsv': 'data',  # Tab Separated Values
+    'wndb': 'data',
+    'xls': 'data',
+    'xlsx': 'data',
+    'xml': 'data',
+    'yaml': 'data',  # configuration files
+    'yml': 'data',  # configuration files
+
+    # markup, office
+    'abw': 'documents',
+    'bib': 'documents',
+    'bibtex': 'documents',
+    'epub': 'documents',
+    'latex': 'documents',
+    'ltx': 'documents',
+    'markdn': 'documents',
+    'markdown': 'documents',
+    'md': 'documents',
+    'mdown': 'documents',
+    'pdf': 'documents',
+    'pub': 'documents',
+    'rst': 'documents',
+    'rtf': 'documents',
+    'tex': 'documents',
+    'text': 'documents',
+    'txt': 'documents',
+    # office
+    'doc': 'documents',  # many various applications
+    'docx': 'documents',  # Microsoft Word
+    'odp': 'documents',  # OpenDocument presentation document, LibreOffice
+    'ott': 'documents',  # OpenDocument text document, LibreOffice
+    'ppt': 'documents',  # Microsoft PowerPoint presentation
+    'pptx': 'documents',  # Microsoft PowerPoint presentation
+
+    # executable code, executable file, or executable program, Shell scripts, installation archives
+    'action': 'executables',
+    'apk': 'executables',
+    'app': 'executables',
+    'applescript': 'executables',
+    'application': 'executables',
+    'appref-ms': 'executables',
+    'ba_': 'executables',
+    'bash': 'executables',
+    'bat': 'executables',
+    'bin': 'executables',
+    'bsh': 'executables',
+    'cmd': 'executables',
+    'com': 'executables',
+    'command': 'executables',
+    'csh': 'executables',
+    'deb': 'executables',  # installation package
+    'elf': 'executables',
+    'ex_': 'executables',
+    'exe': 'executables',
+    'ipa': 'executables',
+    'ksh': 'executables',
+    'mpkg': 'executables',
+    'msi': 'executables',  # Microsoft Windows Installer installation package
+    'ps1': 'executables',  # PowerShell
+    'ps2': 'executables',
+    'psc1': 'executables',
+    'psc2': 'executables',
+    'run': 'executables',
+    'sh': 'executables',
+    'tcsh': 'executables',
+    'vbe': 'executables',
+    'vbs': 'executables',
+    'workflow': 'executables',
+    'wsf': 'executables',
+    'zsh': 'executables',
+    #
+    'a': 'executables',
+    'dll': 'executables',
+    'lib': 'executables',
+    'o': 'executables',
+    'so': 'executables',
+
+    'fon': 'fonts',
+    'font': 'fonts',
+    'ttf': 'fonts',
+    'woff': 'fonts',
+    'woff2': 'fonts',
+
+    'apng': 'images',
+    'bmp': 'images',
+    'dib': 'images',
+    'djv': 'images',
+    'djvu': 'images',
+    'gif': 'images',
+    'ico': 'images',
+    'icon': 'images',
+    'jfif': 'images',
+    'jpeg': 'images',
+    'jpg': 'images',
+    'pic': 'images',
+    'pict': 'images',
+    'pjp': 'images',
+    'pjpeg': 'images',
+    'pjpg': 'images',
+    'png': 'images',
+    'raw': 'images',
+    'svg': 'images',
+    'svgz': 'images',
+    'tif': 'images',
+    'tiff': 'images',
+
+    'egg': 'python',
+    'egg-info': 'python',
+    'egg-link': 'python',
+    'epp': 'python',
+    'ipy': 'python',
+    'ipynb': 'python',
+    'npy': 'python',
+    'npz': 'python',
+    'oog': 'python',
+    'p4a': 'python',
+    'pck': 'python',
+    'pcl': 'python',
+    'pickle': 'python',
+    'pil': 'python',
+    'pth': 'python',
+    'pxd': 'python',
+    'pxi': 'python',
+    'py': 'python',
+    'py2': 'python',
+    'py3': 'python',
+    'py3tb': 'python',
+    'pyc': 'python',
+    'pyd': 'python',
+    'pyde': 'python',
+    'pyi': 'python',
+    'pym': 'python',
+    'pyo': 'python',
+    'pyp': 'python',
+    'pyproj ': 'python',
+    'pyt': 'python',
+    'pytb': 'python',
+    'pyw': 'python',
+    'pyx': 'python',
+    'pyz': 'python',
+    'pyzw': 'python',
+    'rpy': 'python',
+    'whl': 'python',
+
+    'asf': 'videos',
+    'avchd': 'videos',
+    'avi': 'videos',
+    'flv': 'videos',
+    'h264': 'videos',
+    'm4v': 'videos',
+    'mkv': 'videos',
+    'mov': 'videos',
+    'mpv': 'videos',
+    'ogm': 'videos',
+    'ogv': 'videos',
+    'ogx': 'videos',
+    'rm': 'videos',
+    'rmvb': 'videos',
+    'qt': 'videos',
+    'qtff': 'videos',
+    'swf': 'videos',
+    'vob': 'videos',
+    'wmv': 'videos'
+}

--- a/count_files/utils/help_system_extension.py
+++ b/count_files/utils/help_system_extension.py
@@ -5,7 +5,7 @@ from textwrap import fill
 from itertools import chain
 import cmd
 
-from count_files.utils.help_text import indexes, docs_text, docs_groups_text, \
+from count_files.utils.help_text import indexes, docs_text, \
     docs_sort_text, docs_args_text, docs_list_text, docs_general_text
 from count_files.settings import START_TEXT_WIDTH
 
@@ -22,8 +22,6 @@ class HelpCmd(cmd.Cmd):
     more about search by short/long argument name
     help> sort
     more about sorting arguments by purpose or type
-    help> groups
-    more about sorting arguments by group
     help> <topic>
     search by argument or group name, certain search words
     """
@@ -45,7 +43,7 @@ class HelpCmd(cmd.Cmd):
 
     def emptyline(self):
         """Method called when an empty line is entered in response to the prompt."""
-        print('Please enter command name(cmd, help, quit) or search word.')
+        print('Please enter command name(help, quit) or search word.')
 
     def default(self, arg: str):
         """Search in help text."""
@@ -54,7 +52,7 @@ class HelpCmd(cmd.Cmd):
     def print_help_text(self, text: str):
         """Print an adaptive and formatted help text for section or search results.
 
-        Sections: help> [list, args, sort, groups]
+        Sections: help> [list, args, sort]
         Search: help> argument or group name
         :param text: section, argument or group help text
         :return:
@@ -67,7 +65,7 @@ class HelpCmd(cmd.Cmd):
         """Search for help text by topic(argument or group name, search words).
 
         Display corresponding help message for:
-        help> [list, args, sort, groups]
+        help> [list, args, sort]
         help> <topic>
         searching or sorting using indexes from count_files.utils.help_text.py
         default: show long description for <topic in lower case>,
@@ -80,8 +78,6 @@ class HelpCmd(cmd.Cmd):
             self.print_help_text(docs_args_text)
         elif key_lower == 'sort':
             self.print_help_text(docs_sort_text)
-        elif key_lower == 'groups':
-            self.print_help_text(docs_groups_text)
         elif key_lower == 'list':
             self.print_help_text(docs_list_text)
         elif key_lower not in set(chain.from_iterable(indexes.keys())):

--- a/count_files/utils/help_text.py
+++ b/count_files/utils/help_text.py
@@ -5,40 +5,38 @@ from count_files.utils.viewing_modes import show_help_columns
 
 docs_text = f"""COUNT FILES HELP.
 
-Search in help text by topic.
-Start this interactive help:
-    count-files --help-cmd
-Commands:
 More about Count Files Help usage(this section)
     help> help
 To quit this utility, just type "quit"
     help> quit
-
-BASIC USAGE EXAMPLES:
-Topic - argument or group name, certain words for searching or sorting.
+    
+SEARCH FOR ARGUMENTS:
+Search in help text by topic. Topic - argument or group name.
+Show more detailed help text: Topic must be in lower case.
     help> topic
 Show short help text: Topic must be in upper case or with one letter in upper case.
     help> TOPIC
-Show more detailed help text: Topic must be in lower case.
-    help> topic
 Search by short/long argument name:
     help> st
     help> supported-types
-Sorting arguments by group, including group description:
-(count, search or total)
+  
+SORTING ARGUMENTS:
+Get all count arguments and group description:
     help> count
+All certain words for sorting:
+Sorting arguments by group, including group description - count, search or total.
+Get only group description - count-group or cg, search-group or sg, total-group or tg.
+Get all group descriptions - groups.
+Sorting arguments by purpose - service, common, special.
+Sorting arguments by type - positional or optional
 
-ADDITIONAL SECTIONS:
+ALSO USE:
 Get a list of available topics for searching or sorting.
     help> list
 More about search by short/long argument name.
     help> args
 More about sorting arguments by purpose or type.
     help> sort
-More about sorting arguments by group.
-    help> groups
- 
-ALSO USE:
 Get the standard argparse help with a brief description of all the arguments.
     count-files --help
 Web Docs in English, Portuguese, Russian and Ukrainian:
@@ -53,7 +51,7 @@ arguments = [
              # optional
              'all', 'a', 'case-sensitive', 'c',
              'file-extension', 'fe', 'filename-match', 'fm', 'file-sizes', 'fs',
-             'help', 'h', 'help-cmd', 'hc',
+             'group', 'g', 'help', 'h', 'help-cmd', 'hc',
              'no-feedback', 'nf', 'no-recursion', 'nr',
              'preview', 'p', 'preview-size', 'ps', 'show-folders', 'sf',
              'sort-alpha', 'alpha', 'supported-types', 'st', 'total', 't', 'total-size', 'ts', 'version', 'v']
@@ -99,7 +97,7 @@ Common arguments: directory path and sorting settings that are common to search 
 (path, a or all, c or case-sensitive, nr or no-recursion, nf or no-feedback)
     help> common
 Special arguments: arguments for counting or searching files.
-Count by extension: alpha or sort-alpha;
+Count by extension: alpha or sort-alpha, g or group;
 Total number of files: t or total, sf or show-folders, ts or total-size;
 Search by extension: fe or file-extension, fm or filename-match, fs or file-sizes, p or preview, ps or preview-size.
     help> special
@@ -116,28 +114,9 @@ group_names = [
     'cg, count-group', 'count',
     'sg, search-group', 'search',
     'tg, total-group', 'total',
-    # all group descriptions
-    'group'
+    # all groups
+    'groups'
 ]
-
-docs_groups_text = f"""COUNT FILES HELP(GROUPS).
-
-AVAILABLE GROUP NAMES:
-
-{show_help_columns(column_version=group_names, list_version=sorted(group_names[2:]), num_columns=2)}
-
-SORTING ARGUMENTS BY GROUP:
-Sorting arguments by group, including group description.
-    help> count
-    help> search
-    help> total
-Get group description.
-(count-group or cg, search-group or sg, total-group or tg)
-    help> count-group
-    help> tg
-Get all group descriptions.
-    help> group
-"""
 
 docs_general_text = f"""ALSO USE:
 Get the standard argparse help with a brief description of all the arguments.
@@ -302,7 +281,7 @@ topics = {
                 '(e.g.: .txt, .py, .html, .css) and the total number of files found. '
                 'All file extensions in the table will be displayed in uppercase (default). '
                 'Example: count-files <arguments>. '
-                'Usage: count-files [-a, --all] [-alpha, --sort-alpha] '
+                'Usage: count-files [-a, --all] [-alpha, --sort-alpha] [-g, --group] '
                 '[-c, --case-sensitive] [-nr, --no-recursion] [-nf, --no-feedback] [path].'
     },
     'sort-alpha': {
@@ -314,6 +293,12 @@ topics = {
                 'To sort the extensions alphabetically, use the -alpha or --sort-alpha argument. '
                 'Example: count-files ---sort-alpha ~/Documents <arguments>.'
     },
+    'group': {
+        'name': '-g, --group',
+        'short': 'Group file extensions by type (e.g. images, videos).',
+        'long': 'Group file extensions by type: archives, audio, videos, data, documents, '
+                'executables, fonts, images, Python related extensions, videos, and other files. '
+                'Example: count-files --group ~/Documents <optional arguments>.'},
     'search-group': {
         'name': 'File searching by extension or by pattern',
         'short': 'Search for files with a given extension or files matching a specific pattern. '
@@ -430,7 +415,7 @@ indexes = {
     ('nf', 'no-feedback', 'no', 'feedback', 'common', 'optional'):
         [topics['no-feedback']['name'], topics['no-feedback']['short'], topics['no-feedback']['long']],
 
-    ('total-group', 'group', 'total', 'tg'):
+    ('total-group', 'groups', 'total', 'tg'):
         [topics['total-group']['name'], topics['total-group']['short'], topics['total-group']['long']],
     ('t', 'total', 'extension', 'special', 'optional'):
         [topics['total']['name'], topics['total']['short'], topics['total']['long']],
@@ -439,12 +424,14 @@ indexes = {
     ('ts', 'total-size', 'total', 'size', 'special', 'optional'):
         [topics['total-size']['name'], topics['total-size']['short'], topics['total-size']['long']],
 
-    ('count-group', 'group', 'count', 'cg'):
+    ('count-group', 'groups', 'count', 'cg'):
         [topics['count-group']['name'], topics['count-group']['short'], topics['count-group']['long']],
     ('alpha', 'sort-alpha', 'count', 'special', 'optional'):
         [topics['sort-alpha']['name'], topics['sort-alpha']['short'], topics['sort-alpha']['long']],
+    ('g', 'group', 'count', 'special', 'optional'):
+        [topics['group']['name'], topics['group']['short'], topics['group']['long']],
 
-    ('search-group', 'group', 'search', 'sg'):
+    ('search-group', 'groups', 'search', 'sg'):
         [topics['search-group']['name'], topics['search-group']['short'], topics['search-group']['long']],
     ('fe', 'file-extension', 'file', 'extension', 'search', 'special', 'optional'):
         [topics['file-extension']['name'], topics['file-extension']['short'], topics['file-extension']['long']],

--- a/count_files/utils/text_extensions.py
+++ b/count_files/utils/text_extensions.py
@@ -9,43 +9,53 @@ and not registered types
 
 
 text_extensions_and_mime_types = {
-    'py': '',  # Python Script, application/x-python-code, text/x-python, text/plain
-    'pyw': '',  # Windows Python GUI Source File
-    'pyt': '',  # Python Toolbox, text/plain
-    'rpy': '',  # Python Script, Ren'Py Script - text/plain, may be Touhou Project Replay File
-    'pyx': '',  # Cython, Pyrex Source Code File, text/plain
-    'pxd': '',  # Cython, Pyrex Definition File, text/plain
-    'pyi': '',  # Stub Files, text/plain
     'ipy': '',  # IPython Script, text/plain
     'ipynb': '',  # Jupyter Notebook Files, text/plain, actually json-based
-    'go': '',  # Go Source Code File, text/plain
-    'dart': '',  # Dart Source Code File, text/plain
-    'lisp': '',  # Lisp Source Code File, text/plain
-    'php': '',  # PHP, application/x-httpd-php, text/php, application/php, magnus-internal/shellcgi, application/x-php
+    'pxd': '',  # Cython, Pyrex Definition File, text/plain
+    'pxi': '',
+    'py': '',  # Python Script, application/x-python-code, text/x-python, text/plain
+    'py3': '',  # Python Script
+    'py3tb': '',
+    'pyde': '',
+    'pyi': '',  # Stub Files, text/plain
+    'pyp': '',
+    'pyproj': '',  # Microsoft Visual Studio Python project(xml)
+    'pyt': '',  # Python Toolbox, text/plain
+    'pytb': '',
+    'pyw': '',  # Windows Python GUI Source File
+    'pyx': '',  # Cython, Pyrex Source Code File, text/plain
+    'rpy': '',  # Python Script, Ren'Py Script - text/plain, may be Touhou Project Replay File
+
     'bat': '',  # DOS Batch File, text/plain
+    'cfg': '',  # Configuration/Settings Files, may be saved in a text format, Windows and Macintosh systems
     'cmd': '',  # Windows Command File, Files similar in functionality to BAT file format, text/plain
-    'sh': '',  # Bash Shell Script - text/plain, or Unix Shell Archive(Compressed Files, .shar)
-    'vbs': '',  # VBScript File
     'cs': '',  # C# Source Code File
-    'erl': '',  # Erlang Source Code File
-    'lua': '',  # Lua Source File
+    'dart': '',  # Dart Source Code File, text/plain
     'ejs': '',  # application/javascript Embedded Java Script
-    'mjs': '',  # application/javascript Node.js ES Module File
+    'erl': '',  # Erlang Source Code File
+    'go': '',  # Go Source Code File, text/plain
     # Windows Initialization File: text/plain, application/textedit, zz-application/zz-winassoc-ini
     # Finale Preferences File, Symbian OS Configuration File, Gravis UltraSound Bank Setup File
     'ini': '',  # text/plain
-    'xml': '',  # Extensible Markup Language
-    'md': '',  # Text Markdown or some binary media files
-    'mdown': '',  # text/markdown
+    'latex': '',  # LaTeX Document
+    'lisp': '',  # Lisp Source Code File, text/plain
+    'ltx': '',  # LaTeX Document
+    'lua': '',  # Lua Source File
     'markdn': '',  # text/markdown
     'markdown': '',  # text/markdown
-    'rst': '',  # reStructuredText File
-    'yml': '',  # YAML Document application/x-yaml
-    'yaml': '',  # YAML Document application/x-yaml
-    'latex': '',  # LaTeX Document
-    'ltx': '',  # LaTeX Document
-    'cfg': '',  # Configuration/Settings Files, may be saved in a text format, Windows and Macintosh systems
+    'md': '',  # Text Markdown or some binary media files
+    'mdown': '',  # text/markdown
+    'mjs': '',  # application/javascript Node.js ES Module File
+    'nim': '',  # Nim Source File
+    'nimble': '',  # Nim Package File
+    'php': '',  # PHP, application/x-httpd-php, text/php, application/php, magnus-internal/shellcgi, application/x-php
     'qss': '',  # Qt Style Sheet
+    'rst': '',  # reStructuredText File
+    'sh': '',  # Bash Shell Script - text/plain, or Unix Shell Archive(Compressed Files, .shar)
+    'vbs': '',  # VBScript File
+    'xml': '',  # Extensible Markup Language
+    'yaml': '',  # YAML Document application/x-yaml
+    'yml': '',  # YAML Document application/x-yaml
 
     # http://svn.apache.org/viewvc/httpd/httpd/trunk/docs/conf/mime.types?view=markup
     # Fri Sep 29 15:10:29 2017 UTC
@@ -121,36 +131,53 @@ text_extensions_and_mime_types = {
     'uu': 'text/x-uuencode',
     'vcs': 'text/x-vcalendar',
     'vcf': 'text/x-vcard',
-}  # 107
+}  # 116
 
 """
 Python related extensions:
-py   Python Script, python.exe
-pyc  Python Compiled File, Python byte code
-pyw  Windows Python GUI Source File, pythonw.exe
-pyo  Python Optimized Code, Compiled Python File, Python byte code
-pyz  Python Archive File, application/x-zip-compressed
-pyzw Python Archive File, application/x-zip-compressed
-pyt  Python declaration data, Python Toolbox
-npy  Python NumPy Array File
-pyd  Python Dynamic Module, an equivalent of DLL format (dynamic link library), Binary
-rpy  Python Script, Ren'Py Script
-whl  Python Wheel Package, Compressed Files
-oog  related to Object Oriented Graphics (OOG) in PyGraph -  Python Graphics Interface
-p4a  Python script, optimized for Google Android system and apps
-pil  Python Image Library font
-pth  Python path configuration, also: common PyTorch convention is to save models using either a .pt or .pth file
-pym  Python preprocessor macro
-ssdf  Simple Structured Data Format, scientific data Python or Matlab
-pickle  Python Pickle data, application/octet-stream, also *.pck, *.pcl, *.pkl(in Python 2)
-ipy  IPython script
-ipynb  IPython notebook, Jupyter Notebook
-egg  Python egg metadata, regenerated from source files by setuptools
-egg-info  Python egg metadata, regenerated from source files by setuptools
-pyx  Cython, Pyrex Source Code File
-pxd  Cython, Pyrex Definition File(like C/C++ header) or Pixlr Layered Image(binary)
-pyi  Stub Files, https://www.python.org/dev/peps/pep-0561/#stub-only-packages,
-     files containing only type information(Type Hints, mypy), empty of runtime code
+py_ext = {
+    'egg': 'Python egg metadata, regenerated from source files by setuptools',
+    'egg-info': 'Python egg metadata, regenerated from source files by setuptools',
+    'egg-link': 'Python Egg Link',
+    'epp': 'Python Egg data',
+    'ipy': 'IPython script',
+    'ipynb': 'IPython notebook, Jupyter Notebook',
+    'npy': 'Python NumPy Array File, binary',
+    'npz': 'A .npz file is a zip file containing multiple .npy files, one for each array (zipped archive).',
+    'oog': 'related to Object Oriented Graphics (OOG) in PyGraph -  Python Graphics Interface',
+    'p': 'Python module, that is converted by process called "picking"',
+    'p4a': 'Python script, optimized for Google Android system and apps',
+    'pickle': 'Python Pickle data, application/octet-stream, also *.pck, *.pcl, *.pkl(in Python 2)',
+    'pil': 'Python Image Library font',
+    'pth': 'Python path configuration, '
+           'also: common PyTorch convention is to save models using either a .pt or .pth file',
+    'pxd': 'Cython, Pyrex Definition File(like C/C++ header) or Pixlr Layered Image(binary)',
+    'pxi': 'Pyrex header',
+    'py': 'Python Script, python.exe',
+    'py2': 'text',
+    'py3': 'text',
+    'py3tb': 'Python traceback, text',
+    'pyc': 'Python Compiled File, Python byte code',
+    'pyd': 'Python Dynamic Module, an equivalent of DLL format (dynamic link library), Binary',
+    'pyde': 'text',
+    'pyi': 'Stub Files, https://www.python.org/dev/peps/pep-0561/#stub-only-packages, '
+           'files containing only type information(Type Hints, mypy), empty of runtime code',
+    'pym': 'Python preprocessor macro',
+    'pyo': 'Python Optimized Code, Compiled Python File, Python byte code',
+    'pyp': 'AllPlan PythonParts, xml file',
+    'pyproj': 'Microsoft Visual Studio Python project(xml)',
+    'pyt': 'Python declaration data, Python Toolbox',
+    'pytb': 'Python traceback, text',
+    'pyw': 'Windows Python GUI Source File, pythonw.exe',
+    'pyx': 'Cython, Pyrex Source Code File',
+    'pyz': 'Python Archive File, application/x-zip-compressed',
+    'pyzw': 'Python Archive File, application/x-zip-compressed',
+    're': 'Python Regular Expressions source code',
+    'rpy': "Python Script, Ren'Py Script",
+    'ssdf': 'Simple Structured Data Format, scientific data Python or Matlab',
+    'whl': 'Python Wheel Package, Compressed Files'
+}
+https://setuptools.readthedocs.io/en/latest/formats.html
 """
 
 """

--- a/count_files/utils/viewing_modes.py
+++ b/count_files/utils/viewing_modes.py
@@ -73,7 +73,16 @@ def show_group_ext_and_freq(data: List[Tuple[str, int]], header: str,
             for line in w:
                 print(line)
     if end_message:
-        print(end_message)
+        if len(end_message) <= term_width:
+            print()
+            print(end_message)
+        else:
+            # if greater than terminal width
+            end_message = wrap(end_message,
+                               width=term_width, initial_indent='', subsequent_indent=' ' * 2)
+            print()
+            for line in end_message:
+                print(line)
     return
 
 
@@ -180,9 +189,13 @@ def show_2columns(data: List[tuple],
                         max_word_width,
                         MAX_TABLE_WIDTH)
 
-    if term_width < (max_word_width + freq_col_width + 5):
-        print("Oops! There isn't enough horizontal space to display the frequency table. \n")
-        return
+    # handle the extreme case when (term_width - freq_col_width - 5) becomes 0 or a negative value
+    # focus on freq and total_occurferences, long extensions are handled with textwrap wrap() below
+    if (term_width - freq_col_width - 5) <= 0:
+        header = '+ EXTENSION: FREQ.'
+        total = f'  Found {total_occurrences} file(s).'
+        return show_group_ext_and_freq(data=data, header=header,
+                                       term_width=term_width, end_message=total)
 
     header = f" {'EXTENSION'.ljust(ext_col_width)} | {'FREQ.'.ljust(freq_col_width)} "
     sep_left = (ext_col_width + 2) * '-'

--- a/tests/test_viewing_modes.py
+++ b/tests/test_viewing_modes.py
@@ -21,8 +21,10 @@ class TestViewingModes(unittest.TestCase):
         self.test_file = self.get_locations('compare_tables', 'test_show_result_list.txt')
         self.test_file_groups = self.get_locations('compare_tables', 'test_show_group_ext_and_freq.txt')
         self.test_file_groups_long = self.get_locations('compare_tables', 'test_show_ext_grouped_by_type.txt')
+        self.test_file_groups_table = self.get_locations('compare_tables', 'test_show_group_ext_and_freq_table.txt')
         self.standard_file_groups = self.get_locations('compare_tables', 'show_group_ext_and_freq.txt')
         self.standard_file_groups_long = self.get_locations('compare_tables', 'show_ext_grouped_by_type.txt')
+        self.standard_file_groups_table = self.get_locations('compare_tables', 'show_group_ext_and_freq_table.txt')
 
         # files generated in def generate_standard_file()/def generate_standard_file_for_total()
         if sys.platform.startswith('win'):
@@ -72,6 +74,19 @@ class TestViewingModes(unittest.TestCase):
                 f.write('documents\n')
                 f.write('   TXT: 3\n')
                 f.write('   MD: 2\n')
+        elif kind == 'table':
+            # term_width = 30, len(total_occurrences) = 30
+            with open(self.standard_file_groups_table, 'w') as f:
+                f.write('+ EXTENSION: FREQ.\n')
+                f.write('   LONG_FREQ:\n')
+                f.write('   100000000000000000000000000\n')
+                f.write('   000\n')
+                f.write('   TXT: 3\n')
+                f.write('   MD: 2\n')
+                f.write('\n')
+                f.write('  Found\n')
+                f.write('  1000000000000000000000000000\n')
+                f.write('  05 file(s).\n')
         elif kind == 'sections':
             # term_width = 30, len(total_occurrences) = 30
             with open(self.standard_file_groups_long, 'w') as f:
@@ -264,6 +279,17 @@ class TestViewingModes(unittest.TestCase):
         params = {'data': data, 'ext_and_group': ext_and_group_dict, 'term_width': 30}
         self.write_to_test_file(self.test_file_groups_long, show_ext_grouped_by_type, **params)
         self.assertEqual(filecmp.cmp(self.test_file_groups_long, self.standard_file_groups_long,
+                                     shallow=False), True)
+
+    def test_show_group_ext_and_freq_table(self):
+        self.generate_standard_file_for_groups(kind='table')
+        data = Counter({'LONG_FREQ': 100000000000000000000000000000, 'TXT': 3, 'MD': 2})
+        total_occurrences = sum(data.values())
+        max_word_width = max(map(len, data.keys()))
+        params = {'data': data.most_common(), 'max_word_width': max_word_width,
+                  'total_occurrences': total_occurrences, 'term_width': 30}
+        self.write_to_test_file(self.test_file_groups_table, show_2columns, **params)
+        self.assertEqual(filecmp.cmp(self.test_file_groups_table, self.standard_file_groups_table,
                                      shallow=False), True)
 
 

--- a/tests/test_viewing_modes.py
+++ b/tests/test_viewing_modes.py
@@ -7,7 +7,8 @@ import filecmp
 from collections import Counter
 
 from count_files.utils.viewing_modes import show_2columns, show_result_for_search_files, \
-    show_start_message, show_help_columns, show_result_for_total
+    show_start_message, show_help_columns, show_result_for_total, show_group_ext_and_freq, \
+    show_ext_grouped_by_type
 from count_files.platforms import get_current_os
 
 
@@ -18,6 +19,11 @@ class TestViewingModes(unittest.TestCase):
         # result of def show_result_for_search_files()/def show_result_for_total()
         self.test_file_total = self.get_locations('compare_tables', 'test_show_result_total.txt')
         self.test_file = self.get_locations('compare_tables', 'test_show_result_list.txt')
+        self.test_file_groups = self.get_locations('compare_tables', 'test_show_group_ext_and_freq.txt')
+        self.test_file_groups_long = self.get_locations('compare_tables', 'test_show_ext_grouped_by_type.txt')
+        self.standard_file_groups = self.get_locations('compare_tables', 'show_group_ext_and_freq.txt')
+        self.standard_file_groups_long = self.get_locations('compare_tables', 'show_ext_grouped_by_type.txt')
+
         # files generated in def generate_standard_file()/def generate_standard_file_for_total()
         if sys.platform.startswith('win'):
             self.standard_file = self.get_locations('compare_tables', 'win_show_result_list.txt')
@@ -58,6 +64,43 @@ class TestViewingModes(unittest.TestCase):
             f.write('   Found 2 file(s).\n')
             f.write('   Total combined size of files found: 1.1 KiB.\n')
             f.write('   Average file size: 567.0 B (max: 1.1 KiB, min: 10.0 B).\n\n')
+        return
+
+    def generate_standard_file_for_groups(self, kind: str):
+        if kind == 'section':
+            with open(self.standard_file_groups, 'w') as f:
+                f.write('documents\n')
+                f.write('   TXT: 3\n')
+                f.write('   MD: 2\n')
+        elif kind == 'sections':
+            # term_width = 30, len(total_occurrences) = 30
+            with open(self.standard_file_groups_long, 'w') as f:
+                text = """+ ARCHIVES(1)
+   7Z: 1
++ AUDIO(1)
+   MP3: 1
++ DOCUMENTS(2)
+   MD: 2
++ PYTHON(2)
+   PY: 2
++ OTHER(2000000000000000000000
+  00000003)
+   INCREDIBLE_LONG_FILE_EXTENS
+   ION_INCREDIBLE_LONG_FILE_EX
+   TENSION_INCREDIBLE_LONG: 10
+   000000000000000000000000000
+   0
+   LONG_FREQ:
+   100000000000000000000000000
+   000
+   HTML: 1
+   0674532431: 1
+   INCREDIBLE_LONG_FILE_EXTENS
+   ION_INCREDIBLE_LONG_FILE_EX
+   TENSION_INCREDIBLE_LONG_FIL
+   E_EXTENSION: 1
+"""
+                f.write(text)
         return
 
     def write_to_test_file(self, filename, func, **kwargs):
@@ -199,6 +242,30 @@ class TestViewingModes(unittest.TestCase):
         self.write_to_test_file(self.test_file_total, show_result_for_total, **params)
         self.assertEqual(filecmp.cmp(self.test_file_total, self.standard_file_total,
                                      shallow=False), True)
+
+    def test_show_group_ext_and_freq(self):
+        self.generate_standard_file_for_groups(kind='section')
+        params = {'data': [('TXT', 3), ('MD', 2)], 'header': 'documents', 'term_width': 200}
+        self.write_to_test_file(self.test_file_groups, show_group_ext_and_freq, **params)
+        self.assertEqual(filecmp.cmp(self.test_file_groups, self.standard_file_groups,
+                                     shallow=False), True)
+
+    def test_show_ext_grouped_by_type(self):
+        from count_files.utils.group_extensions import ext_and_group_dict
+        self.generate_standard_file_for_groups(kind='sections')
+        counter = Counter({'INCREDIBLE_LONG_FILE_EXTENSION_INCREDIBLE_LONG_FILE_EXTENSION_'
+                           'INCREDIBLE_LONG': 100000000000000000000000000000,
+                           'LONG_FREQ': 100000000000000000000000000000,
+                           'MD': 2, 'PY': 2, 'HTML': 1, '0674532431': 1,
+                           'INCREDIBLE_LONG_FILE_EXTENSION_INCREDIBLE_LONG_FILE_EXTENSION_'
+                           'INCREDIBLE_LONG_FILE_EXTENSION': 1,
+                           'MP3': 1, '7Z': 1})
+        data = counter.most_common()
+        params = {'data': data, 'ext_and_group': ext_and_group_dict, 'term_width': 30}
+        self.write_to_test_file(self.test_file_groups_long, show_ext_grouped_by_type, **params)
+        self.assertEqual(filecmp.cmp(self.test_file_groups_long, self.standard_file_groups_long,
+                                     shallow=False), True)
+
 
 # from root directory:
 # run all tests in test_viewing_modes.py


### PR DESCRIPTION
Hello!
### Changes related to default grouping. There is no configuration file yet.

**added -g/--group argument in Count group**

Starts the default grouping:

`count-files --group ~/Documents <optional arguments>`

Functions:

`def group_ext_by_type`
Group file extensions by type.
Used in `def show_ext_grouped_by_type`.

`def show_group_ext_and_freq`
Displays one type group with header and file extensions and its frequency. A list of two columns that adjusts to the width of the terminal.
Used in `def show_ext_grouped_by_type` and in `def show_2columns` (only if long freq)

`def show_ext_grouped_by_type`
Displays a two column list with file extensions and its frequency. Extensions sorted by type (e.g.: images, videos, documents) and by frequency (inside each type group).
Used in `__main__.py`

**updates to handle the extreme case when `(term_width - freq_col_width - 5)` becomes 0 or a negative value**

Show counting results for small terminals.

**added tests**

**updated help text and help-cmd**

**added default groups and extensions**

Common extensions: archives, audio, videos, data, documents, executables, fonts, images, Python related extensions, videos, and other files.

What do you think?
